### PR TITLE
Add storage filter for filtering PVC resources among all the resources present

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -179,14 +179,6 @@ func MakeRegistry() *Registry {
 				{Value: "hide", Label: "Hide Uncontained", filter: render.IsNotPseudo, filterPseudo: true},
 			},
 		},
-                {
-			ID:      "storage",
-		        Default: "Off",
-		        Options: []APITopologyOption{
-			    {Value: "Off", Label: "Storage Off", filter: nil, filterPseudo: false},
-			    {Value: "On", Label: "Storage On", filter: render.IsPvc, filterPseudo: false},
-		        },
-	        },
 	}
 
 	unconnectedFilter := []APITopologyOptionGroup{

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -47,6 +47,14 @@ var (
 			{Value: "hide", Label: "Hide Unmanaged", filter: render.IsNotPseudo, filterPseudo: true},
 		},
 	}
+        storageFilter  = APITopologyOptionGroup{
+		ID:      "storage",
+		Default: "Off",
+		Options: []APITopologyOption{
+			{Value: "Off", Label: "Storage Off", filter: nil, filterPseudo: false},
+			{Value: "On", Label: "Storage On", filter: render.IsPvc, filterPseudo: false},
+		},
+	}
 )
 
 // namespaceFilters generates a namespace selector option group based on the given namespaces
@@ -171,6 +179,14 @@ func MakeRegistry() *Registry {
 				{Value: "hide", Label: "Hide Uncontained", filter: render.IsNotPseudo, filterPseudo: true},
 			},
 		},
+                {
+			ID:      "storage",
+		        Default: "Off",
+		        Options: []APITopologyOption{
+			    {Value: "Off", Label: "Storage Off", filter: nil, filterPseudo: false},
+			    {Value: "On", Label: "Storage On", filter: render.IsPvc, filterPseudo: false},
+		        },
+	        },
 	}
 
 	unconnectedFilter := []APITopologyOptionGroup{
@@ -229,7 +245,7 @@ func MakeRegistry() *Registry {
 			renderer:    render.PodRenderer,
 			Name:        "Pods",
 			Rank:        3,
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			Options:     []APITopologyOptionGroup{storageFilter, unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -237,7 +253,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.KubeControllerRenderer,
 			Name:        "controllers",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			Options:     []APITopologyOptionGroup{storageFilter, unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -245,7 +261,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.PodServiceRenderer,
 			Name:        "services",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			Options:     []APITopologyOptionGroup{storageFilter, unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -10,10 +10,13 @@ import (
 
 // These constants are keys used in node metadata
 const (
-	Name        = report.KubernetesName
-	Namespace   = report.KubernetesNamespace
-	Created     = report.KubernetesCreated
-	LabelPrefix = "kubernetes_labels_"
+	Name                = report.KubernetesName
+	Namespace           = report.KubernetesNamespace
+	Created             = report.KubernetesCreated
+       OpenEBSCtrlLabel    = report.KubernetesOpenebsCtrlLabel
+	OpenEBSCtrlSvcLabel = report.KubernetesOpenebsCtrlSvcLabel
+	OpenEBSRepLabel     = report.KubernetesOpenebsRepLabel
+	LabelPrefix         = "kubernetes_labels_"
 )
 
 // Meta represents a metadata information about a Kubernetes object

--- a/render/filters.go
+++ b/render/filters.go
@@ -303,6 +303,21 @@ func IsTopology(topology string) FilterFunc {
 // mimicing the check performed by MakeFilter() instead of the more complex check in IsNotPseudo()
 var IsPseudoTopology = IsTopology(Pseudo)
 
+// IsPvc returns true if resource has OpenEBS labels such as openebs/controller with value jiva-controller, openebs/controller-service with value jiva-controller-service or openebs/replica with value jiva-replica
+func IsPvc(n report.Node) bool {
+    name, _ := n.Latest.Lookup(kubernetes.Name)
+    containerName, _ := n.Latest.Lookup(docker.ContainerName)
+    if (strings.Contains(name, "pvc") || strings.Contains(containerName, "pvc")) {
+        OpenEBS_Ctrl_label, _     := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
+        OpenEBS_Ctrl_Svc_label, _ := n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
+        OpenEBS_Rep_label, _      := n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
+        if OpenEBS_Ctrl_label == "jiva-controller" || OpenEBS_Ctrl_Svc_label == "jiva-controller-service" || OpenEBS_Rep_label == "jiva-replica" || strings.Contains(containerName, "pvc"){
+        	return true
+        }
+    }
+    return false
+}
+
 var systemContainerNames = map[string]struct{}{
 	"weavescope": {},
 	"weavedns":   {},

--- a/render/filters.go
+++ b/render/filters.go
@@ -308,12 +308,18 @@ func IsPvc(n report.Node) bool {
     name, _ := n.Latest.Lookup(kubernetes.Name)
     containerName, _ := n.Latest.Lookup(docker.ContainerName)
     if (strings.Contains(name, "pvc") || strings.Contains(containerName, "pvc")) {
-        OpenEBS_Ctrl_label, _     := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
-        OpenEBS_Ctrl_Svc_label, _ := n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
-        OpenEBS_Rep_label, _      := n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
-        if OpenEBS_Ctrl_label == "jiva-controller" || OpenEBS_Ctrl_Svc_label == "jiva-controller-service" || OpenEBS_Rep_label == "jiva-replica" || strings.Contains(containerName, "pvc"){
-        	return true
-        }
+        _, ok    := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
+        if ok {
+			return true
+		}
+        _, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel) 
+        if ok {
+			return true
+		}
+        _, ok      = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
+        if ok {
+			return true
+		}
     }
     return false
 }

--- a/render/filters.go
+++ b/render/filters.go
@@ -311,15 +311,15 @@ func IsPvc(n report.Node) bool {
         _, ok    := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
         if ok {
 			return true
-		}
+	      }
         _, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel) 
         if ok {
 			return true
-		}
+              }
         _, ok      = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
         if ok {
 			return true
-		}
+	      }
     }
     return false
 }

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -72,6 +72,9 @@ const (
 	KubernetesStateDeleted         = "deleted"
 	KubernetesType                 = "kubernetes_type"
 	KubernetesPorts                = "kubernetes_ports"
+       KubernetesOpenebsCtrlLabel     = "kubernetes_labels_openebs/controller"
+	KubernetesOpenebsCtrlSvcLabel  = "kubernetes_labels_openebs/controller-service"
+	KubernetesOpenebsRepLabel      = "kubernetes_labels_openebs/replica"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
- Add a storage filter having value storage on/storage off for filtering PVCs such as pvc pods, pvc   
  controllers or services among pods, controllers or services when storage filter is turned on.
- The storage filter will filter PVCs resources on the basis of openebs labels attached with a given 
   resource such as openebs/controller or openebs/replica or openebs/controller-service.
- If a resource contains one of the above openebs_labels then it is filtered out as a PVC.

  Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>