### PR TITLE
Add storage filter for filtering PVC resources among all the resources present

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -47,6 +47,14 @@ var (
 			{Value: "hide", Label: "Hide Unmanaged", filter: render.IsNotPseudo, filterPseudo: true},
 		},
 	}
+	storageFilter  = APITopologyOptionGroup{
+		ID:      "storage",
+		Default: "Off",
+		Options: []APITopologyOption{
+			{Value: "Off", Label: "Storage Off", filter: nil, filterPseudo: false},
+			{Value: "On", Label: "Storage On", filter: render.IsPvc, filterPseudo: false},
+		},
+	}
 )
 
 // namespaceFilters generates a namespace selector option group based on the given namespaces
@@ -229,7 +237,7 @@ func MakeRegistry() *Registry {
 			renderer:    render.PodRenderer,
 			Name:        "Pods",
 			Rank:        3,
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			Options:     []APITopologyOptionGroup{storageFilter, unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -237,7 +245,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.KubeControllerRenderer,
 			Name:        "controllers",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			Options:     []APITopologyOptionGroup{storageFilter, unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -245,7 +253,7 @@ func MakeRegistry() *Registry {
 			parent:      podsID,
 			renderer:    render.PodServiceRenderer,
 			Name:        "services",
-			Options:     []APITopologyOptionGroup{unmanagedFilter},
+			Options:     []APITopologyOptionGroup{storageFilter, unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -10,10 +10,13 @@ import (
 
 // These constants are keys used in node metadata
 const (
-	Name        = report.KubernetesName
-	Namespace   = report.KubernetesNamespace
-	Created     = report.KubernetesCreated
-	LabelPrefix = "kubernetes_labels_"
+	Name                = report.KubernetesName
+	Namespace           = report.KubernetesNamespace
+	Created             = report.KubernetesCreated
+	OpenEBSCtrlLabel    = report.KubernetesOpenebsCtrlLabel
+       OpenEBSCtrlSvcLabel = report.KubernetesOpenebsCtrlSvcLabel
+       OpenEBSRepLabel     = report.KubernetesOpenebsRepLabel
+	LabelPrefix         = "kubernetes_labels_"
 )
 
 // Meta represents a metadata information about a Kubernetes object

--- a/render/filters.go
+++ b/render/filters.go
@@ -310,16 +310,16 @@ func IsPvc(n report.Node) bool {
     if (strings.Contains(name, "pvc") || strings.Contains(containerName, "pvc")) {
         _, ok := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
         if ok {
-			return true
-	      }
-        _, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
-        if ok {
-			return true
-              }
-        _, ok = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
-        if ok {
-			return true
-	      }
+		return true
+        }
+	_, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
+	if ok {
+		return true
+	}
+	_, ok = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
+	if ok {
+		return true
+	}
     }
     return false
 }

--- a/render/filters.go
+++ b/render/filters.go
@@ -303,6 +303,27 @@ func IsTopology(topology string) FilterFunc {
 // mimicing the check performed by MakeFilter() instead of the more complex check in IsNotPseudo()
 var IsPseudoTopology = IsTopology(Pseudo)
 
+// IsPvc returns true if resource has OpenEBS labels such as openebs/controller with value jiva-controller, openebs/controller-service with value jiva-controller-service or openebs/replica with value jiva-replica
+func IsPvc(n report.Node) bool {
+    name, _ := n.Latest.Lookup(kubernetes.Name)
+    containerName, _ := n.Latest.Lookup(docker.ContainerName)
+    if (strings.Contains(name, "pvc") || strings.Contains(containerName, "pvc")) {
+        _, ok := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
+        if ok {
+			return true
+	      }
+        _, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
+        if ok {
+			return true
+              }
+        _, ok = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
+        if ok {
+			return true
+	      }
+    }
+    return false
+}
+
 var systemContainerNames = map[string]struct{}{
 	"weavescope": {},
 	"weavedns":   {},

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -72,6 +72,9 @@ const (
 	KubernetesStateDeleted         = "deleted"
 	KubernetesType                 = "kubernetes_type"
 	KubernetesPorts                = "kubernetes_ports"
+	KubernetesOpenebsCtrlLabel     = "kubernetes_labels_openebs/controller"
+	KubernetesOpenebsCtrlSvcLabel  = "kubernetes_labels_openebs/controller-service"
+	KubernetesOpenebsRepLabel      = "kubernetes_labels_openebs/replica"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
- Add a storage filter having value storage on/storage off for filtering PVCs such as pvc pods, pvc   
  controllers or services among pods, controllers or services when storage filter is turned on.
- The storage filter will filter PVCs resources on the basis of openebs labels attached with a given 
   resource such as openebs/controller or openebs/replica or openebs/controller-service.
- If a resource contains one of the above openebs_labels then it is filtered out as a PVC.

   Fixes : #4 

  Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>