### PR TITLE
Add config to integrate coveralls and circle CI with scope

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: IBNv2VG5EUWlz8dZKSPQwG4MWNbsdbB5p

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Weave Scope - Troubleshooting & Monitoring for Docker & Kubernetes
 
-[![Circle CI](https://circleci.com/gh/weaveworks/scope/tree/master.svg?style=shield)](https://circleci.com/gh/weaveworks/scope/tree/master)
-[![Coverage Status](https://coveralls.io/repos/weaveworks/scope/badge.svg)](https://coveralls.io/r/weaveworks/scope)
+[![CircleCI](https://circleci.com/gh/openebs/scope.svg?style=svg)](https://circleci.com/gh/openebs/scope)
+[![Coverage Status](https://coveralls.io/repos/github/openebs/scope/badge.svg?branch=master)](https://coveralls.io/github/openebs/scope?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/weaveworks/scope)](https://goreportcard.com/report/github.com/weaveworks/scope)
 [![Slack Status](https://slack.weave.works/badge.svg)](https://slack.weave.works)
 [![Docker Pulls](https://img.shields.io/docker/pulls/weaveworks/scope.svg?maxAge=604800)](https://hub.docker.com/r/weaveworks/scope/)

--- a/circle.yml
+++ b/circle.yml
@@ -62,5 +62,6 @@ deployment:
     branch: staging
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push openebs/scope
+      - docker push openebs/scope:$(./tools/image-tag)
+
 


### PR DESCRIPTION
- This will automatically trigger when the PR is raised and set up coveralls ,it gives the coverage reports.
- Added a config only the docker image with the tag is being pushed to docker hub when merged.


Epic: #17 

Signed-off-by: Pradeepkumarbk <pradeepkumar.bk96@gmail.com>
