### PR TITLE
Add topology inside persistent volume tab by Mock-JSON

### DIFF
--- a/mock-server/json/pv.json
+++ b/mock-server/json/pv.json
@@ -1,0 +1,111 @@
+{
+  "add": [
+    {
+      "id": "d03e0a31",
+      "label": "pvc-cfd470d2",
+      "rank": "/pvc-cfd470d2-282a-11e8-b0a2-141877a4a32a",
+      "shape": "circle",
+      "metadata": [
+        {
+          "id": "kubernetes_created",
+          "label": "Created",
+          "value": "2018-03-15T08:28:18Z",
+          "priority": 3.0,
+          "dataType": "datetime"
+        }
+      ],
+      "tables": [
+        {
+          "id": "kubernetes_labels_",
+          "label": "Kubernetes Labels",
+          "type": "property-list",
+          "columns": null,
+          "rows": []
+        }
+      ],
+      "adjacency": [
+				"cfd470d2-282a;<namespace>",
+				"cfd470d2-282a-11e8-b0a2;<namespace>",
+				"cfd470d2-282a-11e8-b0a2-141877a4a32a;<namespace>"
+			]
+    },
+    {
+      "id": "cfd470d2-282a-11e8-b0a2-141877a4a32a;<namespace>",
+      "label": "demo-vol1-claim",
+      "rank": "/demo-vol1-claim",
+      "shape": "square",
+      "metadata": [
+        {
+          "id": "kubernetes_created",
+          "label": "Created",
+          "value": "2018-03-15T08:28:17Z",
+          "priority": 3.0,
+          "dataType": "datetime"
+        }
+      ],
+      "tables": [
+        {
+          "id": "kubernetes_labels_",
+          "label": "Kubernetes Labels",
+          "type": "property-list",
+          "columns": null,
+          "rows": []
+        }
+      ]
+    },
+    {
+      "id": "cfd470d2-282a-11e8-b0a2;<namespace>",
+      "label": "SC-ISCSI-general",
+      "rank": "/demo-vol2-claim",
+      "shape": "pentagon",
+      "metadata": [
+        {
+          "id": "kubernetes_created",
+          "label": "Created",
+          "value": "2018-03-15T08:28:17Z",
+          "priority": 3.0,
+          "dataType": "datetime"
+        }
+      ],
+      "tables": [
+        {
+          "id": "kubernetes_labels_",
+          "label": "Kubernetes Labels",
+          "type": "property-list",
+          "columns": null,
+          "rows": []
+        }
+      ]
+    },
+    {
+      "id": "cfd470d2-282a;<namespace>",
+      "label": "percona-65779b6584-mjbkk",
+      "rank": "/demo-vol2-claim",
+      "shape": "hexagon",
+      "metadata": [
+        {
+          "id": "kubernetes_created",
+          "label": "Created",
+          "value": "2018-03-15T08:28:17Z",
+          "priority": 3.0,
+          "dataType": "datetime"
+        }
+      ],
+      "tables": [
+        {
+          "id": "kubernetes_labels_",
+          "label": "Kubernetes Labels",
+          "type": "property-list",
+          "columns": null,
+          "rows": []
+        }
+      ],
+      "adjacency": [
+        "cfd470d2-282a-11e8-b0a2-141877a4a32a;<namespace>"
+      ]
+    }
+  ],
+  "update": null,
+  "remove": null,
+  "reset": true
+}

--- a/mock-server/mock-server.go
+++ b/mock-server/mock-server.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 	"io/ioutil"
+	"log"
+	"net/http"
 	"os"
+	"time"
 )
 
 type apiData struct {
@@ -63,12 +67,72 @@ type Topology struct {
 	URL string `json:"url"`
 }
 
+type persistentvolume struct {
+	Add    interface{} `json:"add"`
+	Update []struct {
+		ID         string `json:"id"`
+		Label      string `json:"label"`
+		LabelMinor string `json:"labelMinor"`
+		Rank       string `json:"rank"`
+		Shape      string `json:"shape"`
+		Metadata   []struct {
+			ID       string  `json:"id"`
+			Label    string  `json:"label"`
+			Value    string  `json:"value"`
+			Priority float64 `json:"priority"`
+			DataType string  `json:"dataType,omitempty"`
+		} `json:"metadata"`
+		Metrics []struct {
+			ID       string      `json:"id"`
+			Label    string      `json:"label"`
+			Format   string      `json:"format,omitempty"`
+			Value    float64     `json:"value"`
+			Priority float64     `json:"priority"`
+			Samples  interface{} `json:"samples"`
+			Min      float64     `json:"min"`
+			Max      float64     `json:"max"`
+			First    time.Time   `json:"first"`
+			Last     time.Time   `json:"last"`
+			URL      string      `json:"url"`
+			Group    string      `json:"group,omitempty"`
+		} `json:"metrics"`
+		Adjacency []string `json:"adjacency"`
+	} `json:"update"`
+	Remove interface{} `json:"remove"`
+}
+
 func main() {
 	router := gin.Default()
+	router.GET("/api/topology/persistentVolume/ws", func(c *gin.Context) {
+		wshandler(c.Writer, c.Request)
+	})
 	router.GET("/api", api)
 	router.GET("/api/topology", topology)
 	router.Run(":4040")
 
+}
+
+// ------ websocket -------------------
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+func wshandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	for {
+		raw, _ := ioutil.ReadFile("json/pv.json")
+		var z persistentvolume
+		json.Unmarshal(raw, &z)
+		conn.WriteJSON(z)
+		return
+	}
 }
 
 /*-------------------------------------------------------*/


### PR DESCRIPTION


- Modified mock-server.go for adding `persistentvolume`
`persistentvolumeclaim` `storageclass` `application pod`

- Added pv.json file that contains details about the topology shown
inside `PERSISTENT VOLUME` tab.

![new](https://user-images.githubusercontent.com/28861964/37588817-5d117a82-2b89-11e8-8147-6a756d099fa8.png)


Signed-off-by: Chandan <chandan.kr404@gmail.com>