### PR TITLE
Add functionality to list all the storage classes under persistent volumes section

### DIFF
--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -15,6 +15,7 @@ import (
 	apibatchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	apiv1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	storage_v1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -39,6 +40,7 @@ type Client interface {
 	WalkNamespaces(f func(NamespaceResource) error) error
 	WalkPersistentVolumeClaim(f func(PersistentVolumeClaim) error) error
 	WalkPersistentVolume(f func(PersistentVolume) error) error
+	WalkStorageClass(f func(StorageClass) error) error
 
 	WatchPods(f func(Event, Pod))
 
@@ -62,6 +64,7 @@ type client struct {
 	namespaceStore             cache.Store
 	persistentVolumeClaimStore cache.Store
 	persistentVolumeStore      cache.Store
+	storageClassStore          cache.Store
 
 	podWatchesMutex sync.Mutex
 	podWatches      []func(Event, Pod)
@@ -148,6 +151,7 @@ func NewClient(config ClientConfig) (Client, error) {
 	result.cronJobStore = result.setupStore("cronjobs")
 	result.persistentVolumeClaimStore = result.setupStore("persistentvolumeclaims")
 	result.persistentVolumeStore = result.setupStore("persistentvolumes")
+	result.storageClassStore = result.setupStore("storageclasses")
 	return result, nil
 }
 
@@ -187,6 +191,8 @@ func (c *client) clientAndType(resource string) (rest.Interface, interface{}, er
 		return c.client.CoreV1().RESTClient(), &apiv1.PersistentVolumeClaim{}, nil
 	case "persistentvolumes":
 		return c.client.CoreV1().RESTClient(), &apiv1.PersistentVolume{}, nil
+	case "storageclasses":
+		return c.client.StorageV1().RESTClient(), &storage_v1.StorageClass{}, nil
 	case "namespaces":
 		return c.client.CoreV1().RESTClient(), &apiv1.Namespace{}, nil
 	case "deployments":
@@ -336,7 +342,7 @@ func (c *client) WalkPersistentVolumeClaim(f func(PersistentVolumeClaim) error) 
 	return nil
 }
 
-// WalkPersistentVolume calls f for each PVC
+// WalkPersistentVolume calls f for each PV
 func (c *client) WalkPersistentVolume(f func(PersistentVolume) error) error {
 	if c.persistentVolumeClaimStore == nil {
 		return nil
@@ -344,6 +350,20 @@ func (c *client) WalkPersistentVolume(f func(PersistentVolume) error) error {
 	for _, m := range c.persistentVolumeStore.List() {
 		p := m.(*apiv1.PersistentVolume)
 		if err := f(NewPV(p)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//WalkStorageClass calls f for each storageclass
+func (c *client) WalkStorageClass(f func(StorageClass) error) error {
+	if c.storageClassStore == nil {
+		return nil
+	}
+	for _, m := range c.storageClassStore.List() {
+		p := m.(*storage_v1.StorageClass)
+		if err := f(NewStorageClass(p)); err != nil {
 			return err
 		}
 	}

--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -15,7 +15,7 @@ import (
 	apibatchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	apiv1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/api/extensions/v1beta1"
-	storage_v1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -192,7 +192,7 @@ func (c *client) clientAndType(resource string) (rest.Interface, interface{}, er
 	case "persistentvolumes":
 		return c.client.CoreV1().RESTClient(), &apiv1.PersistentVolume{}, nil
 	case "storageclasses":
-		return c.client.StorageV1().RESTClient(), &storage_v1.StorageClass{}, nil
+		return c.client.StorageV1().RESTClient(), &storagev1.StorageClass{}, nil
 	case "namespaces":
 		return c.client.CoreV1().RESTClient(), &apiv1.Namespace{}, nil
 	case "deployments":
@@ -362,7 +362,7 @@ func (c *client) WalkStorageClass(f func(StorageClass) error) error {
 		return nil
 	}
 	for _, m := range c.storageClassStore.List() {
-		p := m.(*storage_v1.StorageClass)
+		p := m.(*storagev1.StorageClass)
 		if err := f(NewStorageClass(p)); err != nil {
 			return err
 		}

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -148,6 +148,15 @@ func (c *mockClient) WalkDeployments(f func(kubernetes.Deployment) error) error 
 func (c *mockClient) WalkNamespaces(f func(kubernetes.NamespaceResource) error) error {
 	return nil
 }
+func (c *mockClient) WalkPersistentVolumeClaim(f func(kubernetes.PersistentVolumeClaim) error) error {
+	return nil
+}
+func (c *mockClient) WalkPersistentVolume(f func(kubernetes.PersistentVolume) error) error {
+	return nil
+}
+func (c *mockClient) WalkStorageClass(f func(kubernetes.StorageClass) error) error {
+	return nil
+}
 func (*mockClient) WatchPods(func(kubernetes.Event, kubernetes.Pod)) {}
 func (c *mockClient) GetLogs(namespaceID, podName string, _ []string) (io.ReadCloser, error) {
 	r, ok := c.logs[namespaceID+";"+podName]

--- a/probe/kubernetes/storageclass.go
+++ b/probe/kubernetes/storageclass.go
@@ -17,10 +17,6 @@ type storageClass struct {
 	Meta
 }
 
-type person struct {
-	name string
-}
-
 // NewStorageClass returns new Storage Class type
 func NewStorageClass(p *storage_v1.StorageClass) StorageClass {
 	return &storageClass{StorageClass: p, Meta: meta{p.ObjectMeta}}

--- a/probe/kubernetes/storageclass.go
+++ b/probe/kubernetes/storageclass.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"github.com/weaveworks/scope/report"
-	storage_v1 "k8s.io/api/storage/v1"
+	storagev1 "k8s.io/api/storage/v1"
 )
 
 // StorageClass represent kubernetes StorageClass interface
@@ -13,12 +13,12 @@ type StorageClass interface {
 
 // storageClass represents kubernetes storage classes
 type storageClass struct {
-	*storage_v1.StorageClass
+	*storagev1.StorageClass
 	Meta
 }
 
 // NewStorageClass returns new Storage Class type
-func NewStorageClass(p *storage_v1.StorageClass) StorageClass {
+func NewStorageClass(p *storagev1.StorageClass) StorageClass {
 	return &storageClass{StorageClass: p, Meta: meta{p.ObjectMeta}}
 }
 

--- a/probe/kubernetes/storageclass.go
+++ b/probe/kubernetes/storageclass.go
@@ -1,0 +1,36 @@
+package kubernetes
+
+import (
+	"github.com/weaveworks/scope/report"
+	storage_v1 "k8s.io/api/storage/v1"
+)
+
+// StorageClass represent kubernetes StorageClass interface
+type StorageClass interface {
+	Meta
+	GetNode(probeID string) report.Node
+}
+
+// storageClass represents kubernetes storage classes
+type storageClass struct {
+	*storage_v1.StorageClass
+	Meta
+}
+
+type person struct {
+	name string
+}
+
+// NewStorageClass returns new Storage Class type
+func NewStorageClass(p *storage_v1.StorageClass) StorageClass {
+	return &storageClass{StorageClass: p, Meta: meta{p.ObjectMeta}}
+}
+
+// GetNode returns StorageClass as Node
+func (p *storageClass) GetNode(probeID string) report.Node {
+	return p.MetaNode(report.MakeStorageClassNodeID(p.UID())).WithLatests(map[string]string{
+		report.ControlProbeID: probeID,
+		NodeType:              "StorageClass",
+		Namespace:             p.GetNamespace(),
+	})
+}

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -203,6 +203,15 @@ var nodeSummaryGroupSpecs = []struct {
 			},
 		},
 	},
+	{
+		topologyID: report.StorageClass,
+		NodeSummaryGroup: NodeSummaryGroup{
+			Label: "StorageClass",
+			Columns: []Column{
+				{ID: kubernetes.State, Label: "State"},
+			},
+		},
+	},
 }
 
 func children(rc RenderContext, n report.Node) []NodeSummaryGroup {

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -80,6 +80,7 @@ var renderers = map[string]func(BasicNodeSummary, report.Node) BasicNodeSummary{
 	report.Host:                  hostNodeSummary,
 	report.PersistentVolumeClaim: persistentVolumeClaimNodeSummary,
 	report.PersistentVolume:      persistentVolumeNodeSummary,
+	report.StorageClass:          storageClassNodeSummary,
 	report.Overlay:               weaveNodeSummary,
 	report.Endpoint:              nil, // Do not render
 }
@@ -101,6 +102,7 @@ var primaryAPITopology = map[string]string{
 	report.Host:                  "hosts",
 	report.PersistentVolumeClaim: "persistentvolumeclaim",
 	report.PersistentVolume:      "persistentvolume",
+	report.StorageClass:          "storageclass",
 }
 
 // MakeBasicNodeSummary returns a basic summary of a node, if
@@ -382,6 +384,12 @@ func persistentVolumeClaimNodeSummary(base BasicNodeSummary, n report.Node) Basi
 }
 
 func persistentVolumeNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
+	// TODO: Need to improve more and add Minor label
+	base = addKubernetesLabelAndRank(base, n)
+	return base
+}
+
+func storageClassNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	// TODO: Need to improve more and add Minor label
 	base = addKubernetesLabelAndRank(base, n)
 	return base

--- a/render/pvc.go
+++ b/render/pvc.go
@@ -9,6 +9,7 @@ var PVCRenderer = MakeReduce(
 
 	MapEndpoints(endpoint2PVC, report.PersistentVolumeClaim),
 	MapEndpoints(endpoint2PV, report.PersistentVolume),
+	MapEndpoints(endpoint2StorageClass, report.StorageClass),
 )
 
 // endpoint2PVC returns pvc node ID
@@ -23,6 +24,14 @@ func endpoint2PVC(n report.Node) string {
 func endpoint2PV(n report.Node) string {
 	if pvNodeID, ok := n.Latest.Lookup(report.MakePersistentVolumeNodeID(n.ID)); ok {
 		return pvNodeID
+	}
+	return ""
+}
+
+// endpoint2StorageClass returns StorageClass node ID
+func endpoint2StorageClass(n report.Node) string {
+	if storageclassNodeID, ok := n.Latest.Lookup(report.MakeStorageClassNodeID(n.ID)); ok {
+		return storageclassNodeID
 	}
 	return ""
 }

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -34,4 +34,5 @@ var (
 	SelectOverlay               = TopologySelector(report.Overlay)
 	SelectPersistentVolumeClaim = TopologySelector(report.PersistentVolumeClaim)
 	SelectPersistentVolume      = TopologySelector(report.PersistentVolume)
+	SelectStorageClass          = TopologySelector(report.StorageClass)
 )

--- a/report/id.go
+++ b/report/id.go
@@ -169,6 +169,12 @@ var (
 
 	// ParsePersistentVolumeNodeID parses a persistentvolumeclaim node ID
 	ParsePersistentVolumeNodeID = parseSingleComponentID("persistentvolume")
+
+	// MakeStorageClassNodeID produces a storageclass node ID from its composite parts.
+	MakeStorageClassNodeID = makeSingleComponentID("storageclass")
+
+	// ParseStorageClassNodeID parses a storageclass node ID
+	ParseStorageClassNodeID = parseSingleComponentID("storageclass")
 )
 
 // makeSingleComponentID makes a single-component node id encoder

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -109,6 +109,7 @@ var commonKeys = map[string]string{
 	SwarmService:          SwarmService,
 	PersistentVolumeClaim: PersistentVolumeClaim,
 	PersistentVolume:      PersistentVolume,
+	StorageClass:          StorageClass,
 
 	HostNodeID:             HostNodeID,
 	ControlProbeID:         ControlProbeID,

--- a/report/report.go
+++ b/report/report.go
@@ -31,6 +31,7 @@ const (
 	SwarmService          = "swarm_service"
 	PersistentVolumeClaim = "persistentvolumeclaim"
 	PersistentVolume      = "persistentvolume"
+	StorageClass          = "storageclass"
 
 	// Shapes used for different nodes
 	Circle   = "circle"
@@ -67,6 +68,7 @@ var topologyNames = []string{
 	SwarmService,
 	PersistentVolumeClaim,
 	PersistentVolume,
+	StorageClass,
 }
 
 // Report is the core data type. It's produced by probes, and consumed and
@@ -133,6 +135,10 @@ type Report struct {
 	// PersistentVolume represent all kubernetes PersistentVolumes on hosts running probes.
 	// Metadata includes things like PV id, pv name etc. Edges are not present
 	PersistentVolume Topology
+
+	// StorageClass represent all kubernetes StorageClasses on hosts running probes.
+	// Metadata includes things like storage class id, storage class name etc. Edges are not present
+	StorageClass Topology
 
 	// ContainerImages nodes represent all Docker containers images on
 	// hosts running probes. Metadata includes things like image id, name etc.
@@ -264,6 +270,10 @@ func MakeReport() Report {
 			WithShape(Heptagon).
 			WithLabel("persistentvolume", "persistentvolumes"),
 
+		StorageClass: MakeTopology().
+			WithShape(Triangle).
+			WithLabel("storageclass", "storageclasses"),
+
 		DNS: DNSRecords{},
 
 		Sampling: Sampling{},
@@ -368,6 +378,8 @@ func (r *Report) topology(name string) *Topology {
 		return &r.PersistentVolumeClaim
 	case PersistentVolume:
 		return &r.PersistentVolume
+	case StorageClass:
+		return &r.StorageClass
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>

**What this PR does / why we need it**:
- This PR will add the functionality to list all the storage classes under persistent volumes (sub-topology of PODS) alongwith PVs and PVCs.
- Storage classes will be displayed in triangle shape

**Which issue this PR fixes** 
 - fixes : #23 

