### PR TITLE
Fix indentation in filters.go

### DIFF
--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -38,9 +38,9 @@ type Client interface {
 	WalkStatefulSets(f func(StatefulSet) error) error
 	WalkCronJobs(f func(CronJob) error) error
 	WalkNamespaces(f func(NamespaceResource) error) error
-	WalkPersistentVolumeClaim(f func(PersistentVolumeClaim) error) error
-	WalkPersistentVolume(f func(PersistentVolume) error) error
-	WalkStorageClass(f func(StorageClass) error) error
+	WalkPersistentVolumeClaims(f func(PersistentVolumeClaim) error) error
+	WalkPersistentVolumes(f func(PersistentVolume) error) error
+	WalkStorageClasses(f func(StorageClass) error) error
 
 	WatchPods(f func(Event, Pod))
 
@@ -329,7 +329,7 @@ func (c *client) WalkStatefulSets(f func(StatefulSet) error) error {
 }
 
 // WalkPersistentVolumeClaim calls f for each PVC
-func (c *client) WalkPersistentVolumeClaim(f func(PersistentVolumeClaim) error) error {
+func (c *client) WalkPersistentVolumeClaims(f func(PersistentVolumeClaim) error) error {
 	if c.persistentVolumeClaimStore == nil {
 		return nil
 	}
@@ -343,7 +343,7 @@ func (c *client) WalkPersistentVolumeClaim(f func(PersistentVolumeClaim) error) 
 }
 
 // WalkPersistentVolume calls f for each PV
-func (c *client) WalkPersistentVolume(f func(PersistentVolume) error) error {
+func (c *client) WalkPersistentVolumes(f func(PersistentVolume) error) error {
 	if c.persistentVolumeClaimStore == nil {
 		return nil
 	}
@@ -357,7 +357,7 @@ func (c *client) WalkPersistentVolume(f func(PersistentVolume) error) error {
 }
 
 //WalkStorageClass calls f for each storageclass
-func (c *client) WalkStorageClass(f func(StorageClass) error) error {
+func (c *client) WalkStorageClasses(f func(StorageClass) error) error {
 	if c.storageClassStore == nil {
 		return nil
 	}

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -14,8 +14,8 @@ const (
 	Namespace           = report.KubernetesNamespace
 	Created             = report.KubernetesCreated
 	OpenEBSCtrlLabel    = report.KubernetesOpenebsCtrlLabel
-       OpenEBSCtrlSvcLabel = report.KubernetesOpenebsCtrlSvcLabel
-       OpenEBSRepLabel     = report.KubernetesOpenebsRepLabel
+	OpenEBSCtrlSvcLabel = report.KubernetesOpenebsCtrlSvcLabel
+	OpenEBSRepLabel     = report.KubernetesOpenebsRepLabel
 	LabelPrefix         = "kubernetes_labels_"
 )
 

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -558,7 +558,7 @@ func (r *Reporter) persistentVolumeClaimTopology(probeID string) (report.Topolog
 		pvcs = []PersistentVolumeClaim{}
 	)
 
-	err := r.client.WalkPersistentVolumeClaim(func(p PersistentVolumeClaim) error {
+	err := r.client.WalkPersistentVolumeClaims(func(p PersistentVolumeClaim) error {
 		result.AddNode(p.GetNode(probeID))
 		pvcs = append(pvcs, p)
 		return nil
@@ -576,7 +576,7 @@ func (r *Reporter) persistentVolumeTopology(probeID string) (report.Topology, []
 		pvcs = []PersistentVolume{}
 	)
 
-	err := r.client.WalkPersistentVolume(func(p PersistentVolume) error {
+	err := r.client.WalkPersistentVolumes(func(p PersistentVolume) error {
 		result.AddNode(p.GetNode(probeID))
 		pvcs = append(pvcs, p)
 		return nil
@@ -594,7 +594,7 @@ func (r *Reporter) storageClassTopology(probeID string) (report.Topology, []Stor
 		sc = []StorageClass{}
 	)
 
-	err := r.client.WalkStorageClass(func(p StorageClass) error {
+	err := r.client.WalkStorageClasses(func(p StorageClass) error {
 		result.AddNode(p.GetNode(probeID))
 		sc = append(sc, p)
 		return nil

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -148,13 +148,13 @@ func (c *mockClient) WalkDeployments(f func(kubernetes.Deployment) error) error 
 func (c *mockClient) WalkNamespaces(f func(kubernetes.NamespaceResource) error) error {
 	return nil
 }
-func (c *mockClient) WalkPersistentVolumeClaim(f func(kubernetes.PersistentVolumeClaim) error) error {
+func (c *mockClient) WalkPersistentVolumeClaims(f func(kubernetes.PersistentVolumeClaim) error) error {
 	return nil
 }
-func (c *mockClient) WalkPersistentVolume(f func(kubernetes.PersistentVolume) error) error {
+func (c *mockClient) WalkPersistentVolumes(f func(kubernetes.PersistentVolume) error) error {
 	return nil
 }
-func (c *mockClient) WalkStorageClass(f func(kubernetes.StorageClass) error) error {
+func (c *mockClient) WalkStorageClasses(f func(kubernetes.StorageClass) error) error {
 	return nil
 }
 func (*mockClient) WatchPods(func(kubernetes.Event, kubernetes.Pod)) {}

--- a/render/filters.go
+++ b/render/filters.go
@@ -305,23 +305,23 @@ var IsPseudoTopology = IsTopology(Pseudo)
 
 // IsPvc returns true if resource has OpenEBS labels such as openebs/controller with value jiva-controller, openebs/controller-service with value jiva-controller-service or openebs/replica with value jiva-replica
 func IsPvc(n report.Node) bool {
-    name, _ := n.Latest.Lookup(kubernetes.Name)
-    containerName, _ := n.Latest.Lookup(docker.ContainerName)
-    if (strings.Contains(name, "pvc") || strings.Contains(containerName, "pvc")) {
-        _, ok := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
-        if ok {
-		return true
-        }
-	_, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
-	if ok {
-		return true
+	name, _ := n.Latest.Lookup(kubernetes.Name)
+	containerName, _ := n.Latest.Lookup(docker.ContainerName)
+	if strings.Contains(name, "pvc") || strings.Contains(containerName, "pvc") {
+		_, ok := n.Latest.Lookup(kubernetes.OpenEBSCtrlLabel)
+		if ok {
+			return true
+		}
+		_, ok = n.Latest.Lookup(kubernetes.OpenEBSCtrlSvcLabel)
+		if ok {
+			return true
+		}
+		_, ok = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
+		if ok {
+			return true
+		}
 	}
-	_, ok = n.Latest.Lookup(kubernetes.OpenEBSRepLabel)
-	if ok {
-		return true
-	}
-    }
-    return false
+	return false
 }
 
 var systemContainerNames = map[string]struct{}{


### PR DESCRIPTION
- Fix indentation in file filters.go
- Change function name from walkPersistentVolumeClaim to WalkPersistentVolumeClaims
- Change function name from walkPersistentVolume to walkPersistentVolumes
- Change function name from walkStorageClass to walkStorageClasses

- Change the above function names in reporter_test.go

Signed-off-by: Akash4927 <akashsrivastava4927@gmail.com>
