### PR TITLE
List application pods under Persistent Volumes tab

### DIFF
--- a/probe/kubernetes/applicationpod.go
+++ b/probe/kubernetes/applicationpod.go
@@ -1,0 +1,74 @@
+package kubernetes
+
+import (
+	"strconv"
+
+	"github.com/weaveworks/scope/report"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// ApplicationPod represents a Kubernetes pod
+type ApplicationPod interface {
+	Meta
+	GetApp(probeID string) report.Node
+	RestartCount() uint
+}
+
+type applicationPod struct {
+	*apiv1.Pod
+	Meta
+	parents report.Sets
+	Node    *apiv1.Node
+}
+
+func (p *applicationPod) State() string {
+	return string(p.Status.Phase)
+}
+
+func (p *applicationPod) RestartCount() uint {
+	count := uint(0)
+	for _, cs := range p.Status.ContainerStatuses {
+		count += uint(cs.RestartCount)
+	}
+	return count
+}
+
+func (p *applicationPod) EmptyMetaNode() report.Node {
+	return report.MakeNode("")
+}
+
+func (p *applicationPod) AddParent(topology, id string) {
+	p.parents = p.parents.Add(topology, report.MakeStringSet(id))
+}
+
+// NewApp creates a new Pod
+func NewApp(p *apiv1.Pod) ApplicationPod {
+	return &applicationPod{
+		Pod:     p,
+		Meta:    meta{p.ObjectMeta},
+		parents: report.MakeSets(),
+	}
+}
+
+func (p *applicationPod) GetApp(probeID string) report.Node {
+	for _, v := range p.Spec.Volumes {
+		if v.VolumeSource.PersistentVolumeClaim != nil {
+			latests := map[string]string{
+				State: p.State(),
+				IP:    p.Status.PodIP,
+				report.ControlProbeID: probeID,
+				RestartCount:          strconv.FormatUint(uint64(p.RestartCount()), 10),
+				VolumeClaimName:       v.VolumeSource.PersistentVolumeClaim.ClaimName,
+			}
+
+			if p.Pod.Spec.HostNetwork {
+				latests[IsInHostNetwork] = "true"
+			}
+
+			return p.MetaNode(report.MakePodNodeID(p.UID())).WithLatests(latests).
+				WithParents(p.parents)
+		}
+	}
+	return p.EmptyMetaNode()
+}

--- a/probe/kubernetes/meta.go
+++ b/probe/kubernetes/meta.go
@@ -14,6 +14,7 @@ const (
 	Namespace           = report.KubernetesNamespace
 	Created             = report.KubernetesCreated
 	OpenEBSCtrlLabel    = report.KubernetesOpenebsCtrlLabel
+	VolumeClaimName     = report.KubernetesVolumeClaimName
 	OpenEBSCtrlSvcLabel = report.KubernetesOpenebsCtrlSvcLabel
 	OpenEBSRepLabel     = report.KubernetesOpenebsRepLabel
 	LabelPrefix         = "kubernetes_labels_"

--- a/probe/kubernetes/reporter_test.go
+++ b/probe/kubernetes/reporter_test.go
@@ -157,6 +157,9 @@ func (c *mockClient) WalkPersistentVolumes(f func(kubernetes.PersistentVolume) e
 func (c *mockClient) WalkStorageClasses(f func(kubernetes.StorageClass) error) error {
 	return nil
 }
+func (c *mockClient) WalkApplicationPods(f func(kubernetes.ApplicationPod) error) error {
+	return nil
+}
 func (*mockClient) WatchPods(func(kubernetes.Event, kubernetes.Pod)) {}
 func (c *mockClient) GetLogs(namespaceID, podName string, _ []string) (io.ReadCloser, error) {
 	r, ok := c.logs[namespaceID+";"+podName]

--- a/render/detailed/node.go
+++ b/render/detailed/node.go
@@ -212,6 +212,15 @@ var nodeSummaryGroupSpecs = []struct {
 			},
 		},
 	},
+	{
+		topologyID: report.ApplicationPod,
+		NodeSummaryGroup: NodeSummaryGroup{
+			Label: "Pod",
+			Columns: []Column{
+				{ID: kubernetes.State, Label: "State"},
+			},
+		},
+	},
 }
 
 func children(rc RenderContext, n report.Node) []NodeSummaryGroup {

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -82,6 +82,7 @@ var renderers = map[string]func(BasicNodeSummary, report.Node) BasicNodeSummary{
 	report.PersistentVolume:      persistentVolumeNodeSummary,
 	report.StorageClass:          storageClassNodeSummary,
 	report.Overlay:               weaveNodeSummary,
+	report.ApplicationPod:        applicationPodNodeSummary,
 	report.Endpoint:              nil, // Do not render
 }
 
@@ -103,6 +104,7 @@ var primaryAPITopology = map[string]string{
 	report.PersistentVolumeClaim: "persistentvolumeclaim",
 	report.PersistentVolume:      "persistentvolume",
 	report.StorageClass:          "storageclass",
+	report.ApplicationPod:        "applicationpod",
 }
 
 // MakeBasicNodeSummary returns a basic summary of a node, if
@@ -390,6 +392,12 @@ func persistentVolumeNodeSummary(base BasicNodeSummary, n report.Node) BasicNode
 }
 
 func storageClassNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
+	// TODO: Need to improve more and add Minor label
+	base = addKubernetesLabelAndRank(base, n)
+	return base
+}
+
+func applicationPodNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	// TODO: Need to improve more and add Minor label
 	base = addKubernetesLabelAndRank(base, n)
 	return base

--- a/render/pvc.go
+++ b/render/pvc.go
@@ -10,6 +10,7 @@ var PVCRenderer = MakeReduce(
 	MapEndpoints(endpoint2PVC, report.PersistentVolumeClaim),
 	MapEndpoints(endpoint2PV, report.PersistentVolume),
 	MapEndpoints(endpoint2StorageClass, report.StorageClass),
+	MapEndpoints(endpoint2PVC, report.ApplicationPod),
 )
 
 // endpoint2PVC returns pvc node ID

--- a/render/selectors.go
+++ b/render/selectors.go
@@ -35,4 +35,5 @@ var (
 	SelectPersistentVolumeClaim = TopologySelector(report.PersistentVolumeClaim)
 	SelectPersistentVolume      = TopologySelector(report.PersistentVolume)
 	SelectStorageClass          = TopologySelector(report.StorageClass)
+	ApplicationPod              = TopologySelector(report.ApplicationPod)
 )

--- a/report/id.go
+++ b/report/id.go
@@ -175,6 +175,12 @@ var (
 
 	// ParseStorageClassNodeID parses a storageclass node ID
 	ParseStorageClassNodeID = parseSingleComponentID("storageclass")
+
+	// MakeApplicationPodNodeID produces a application pod node ID from its composite parts.
+	MakeApplicationPodNodeID = makeSingleComponentID("applicationpod")
+
+	// ParseApplicationPodNodeID produces a application pod node ID
+	ParseApplicationPodNodeID = parseSingleComponentID("applicationpod")
 )
 
 // makeSingleComponentID makes a single-component node id encoder

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -75,6 +75,7 @@ const (
 	KubernetesOpenebsCtrlLabel     = "kubernetes_labels_openebs/controller"
 	KubernetesOpenebsCtrlSvcLabel  = "kubernetes_labels_openebs/controller-service"
 	KubernetesOpenebsRepLabel      = "kubernetes_labels_openebs/replica"
+	KubernetesVolumeClaimName      = "kubernetes_volume_claim_name"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"
@@ -110,6 +111,7 @@ var commonKeys = map[string]string{
 	PersistentVolumeClaim: PersistentVolumeClaim,
 	PersistentVolume:      PersistentVolume,
 	StorageClass:          StorageClass,
+	ApplicationPod:        ApplicationPod,
 
 	HostNodeID:             HostNodeID,
 	ControlProbeID:         ControlProbeID,

--- a/report/report.go
+++ b/report/report.go
@@ -32,6 +32,7 @@ const (
 	PersistentVolumeClaim = "persistentvolumeclaim"
 	PersistentVolume      = "persistentvolume"
 	StorageClass          = "storageclass"
+	ApplicationPod        = "applicationpod"
 
 	// Shapes used for different nodes
 	Circle   = "circle"
@@ -69,6 +70,7 @@ var topologyNames = []string{
 	PersistentVolumeClaim,
 	PersistentVolume,
 	StorageClass,
+	ApplicationPod,
 }
 
 // Report is the core data type. It's produced by probes, and consumed and
@@ -139,6 +141,10 @@ type Report struct {
 	// StorageClass represent all kubernetes StorageClasses on hosts running probes.
 	// Metadata includes things like storage class id, storage class name etc. Edges are not present
 	StorageClass Topology
+
+	// ApplicationPod represent all kubernetes application pods on hosts running probes.
+	// Metadata includes things like pod id, name etc. Edges are not present
+	ApplicationPod Topology
 
 	// ContainerImages nodes represent all Docker containers images on
 	// hosts running probes. Metadata includes things like image id, name etc.
@@ -274,6 +280,10 @@ func MakeReport() Report {
 			WithShape(Triangle).
 			WithLabel("storageclass", "storageclasses"),
 
+		ApplicationPod: MakeTopology().
+			WithShape(Hexagon).
+			WithLabel("applicationpod", "applicationpods"),
+
 		DNS: DNSRecords{},
 
 		Sampling: Sampling{},
@@ -380,6 +390,8 @@ func (r *Report) topology(name string) *Topology {
 		return &r.PersistentVolume
 	case StorageClass:
 		return &r.StorageClass
+	case ApplicationPod:
+		return &r.ApplicationPod
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will add functionality to list all the application pods (having volume claim name) under persistent volumes tab (sub-topology of Pods)

Signed-off-by: Akash4927 <akashsrivastava4927@gmail.com>

**Which issue this PR fixes** 
fixes: #52

