### PR TITLE
Get all PV and PVC details when clicked on it

### DIFF
--- a/probe/kubernetes/pv.go
+++ b/probe/kubernetes/pv.go
@@ -27,6 +27,11 @@ func (p *persistentVolume) GetNode(probeID string) report.Node {
 	return p.MetaNode(report.MakePersistentVolumeNodeID(p.UID())).WithLatests(map[string]string{
 		report.ControlProbeID: probeID,
 		NodeType:              "PV",
-		Namespace:             p.GetNamespace(),
+		Claim:                 p.Spec.ClaimRef.Name,
+		StorageClassName:      p.Spec.StorageClassName,
+		Status:                string(p.Status.Phase),
+		AccessModes:           string(p.Spec.AccessModes[0]),
+		ReclaimPolicy:         string(p.Spec.PersistentVolumeReclaimPolicy),
+		Message:               p.Status.Message,
 	})
 }

--- a/probe/kubernetes/pvc.go
+++ b/probe/kubernetes/pvc.go
@@ -32,6 +32,9 @@ func (p *persistentVolumeClaim) GetNode(probeID string) report.Node {
 		report.ControlProbeID: probeID,
 		NodeType:              "PVC",
 		Namespace:             p.GetNamespace(),
+		Status:                string(p.Status.Phase),
+		VolumeName:            p.Spec.VolumeName,
+		AccessModes:           string(p.Spec.AccessModes[0]),
 	})
 }
 
@@ -43,3 +46,4 @@ func (p *persistentVolumeClaim) Selector() (labels.Selector, error) {
 	}
 	return selector, nil
 }
+

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -25,6 +25,13 @@ const (
 	NodeType           = report.KubernetesNodeType
 	Type               = report.KubernetesType
 	Ports              = report.KubernetesPorts
+	Claim              = report.KubernetesClaim
+	StorageClassName   = report.KubernetesStorageClassName
+	AccessModes        = report.KubernetesAccessModes
+	ReclaimPolicy      = report.KubernetesReclaimPolicy
+	Status             = report.KubernetesStatus
+	Message            = report.KubernetesMessage
+	VolumeName         = report.KubernetesVolumeName
 )
 
 // Exposed for testing
@@ -99,15 +106,24 @@ var (
 	CronJobMetricTemplates = PodMetricTemplates
 
 	PersistentVolumeClaimMetadataTemplates = report.MetadataTemplates{
-		NodeType:  {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
-		Namespace: {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
+		NodeType:         {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
+		Namespace:        {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
+		StorageClassName: {ID: StorageClassName, Label: "Storage Class", From: report.FromLatest, Priority: 3},
+		Status:           {ID: Status, Label: "Status", From: report.FromLatest, Priority: 4},
+		VolumeName:       {ID: VolumeName, Label: "Volume", From: report.FromLatest, Priority: 5},
+		AccessModes:      {ID: AccessModes, Label: "Access Modes", From: report.FromLatest, Priority: 6},
 	}
 
 	PersistentVolumeClaimMetricTemplates = PodMetricTemplates
 
 	PersistentVolumeMetadataTemplates = report.MetadataTemplates{
-		NodeType:  {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
-		Namespace: {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
+		NodeType:         {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
+		Claim:            {ID: Claim, Label: "Claim", From: report.FromLatest, Priority: 2},
+		StorageClassName: {ID: StorageClassName, Label: "Storage Class", From: report.FromLatest, Priority: 3},
+		ReclaimPolicy:    {ID: ReclaimPolicy, Label: "Reclaim Policy", From: report.FromLatest, Priority: 4},
+		AccessModes:      {ID: AccessModes, Label: "Access Modes", From: report.FromLatest, Priority: 5},
+		Status:           {ID: Status, Label: "Status", From: report.FromLatest, Priority: 6},
+		Message:          {ID: Message, Label: "Message", From: report.FromLatest, Priority: 7},
 	}
 
 	PersistentVolumeMetricTemplates = PodMetricTemplates

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -76,6 +76,13 @@ const (
 	KubernetesOpenebsCtrlSvcLabel  = "kubernetes_labels_openebs/controller-service"
 	KubernetesOpenebsRepLabel      = "kubernetes_labels_openebs/replica"
 	KubernetesVolumeClaimName      = "kubernetes_volume_claim_name"
+	KubernetesClaim                = "kubernetes_claim"
+	KubernetesStorageClassName     = "kubernetes_storage_class_name"
+	KubernetesAccessModes          = "kubernetes_access_modes"
+	KubernetesReclaimPolicy        = "kubernetes_reclaim_policy"
+	KubernetesStatus               = "kubernetes_status"
+	KubernetesMessage              = "kubernetes_message"
+	KubernetesVolumeName           = "kubernetes_volume_name"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Get all Persistent Volume details inside `node-details-content` div, when clicked on Persistent Volume,
under `PersistentVolume` tab/Subtopology.

- PV details are `Status`, `Volume`, `Label`,etc.

- Get all Peristent Volume Claim details inside `node-details-content` div, when clicked on Persistent
Volume Claim, under `PersistentVolume` tab/Subtopology.

- PVC details are `Namespace`, `Status`, `Volume`, `Access Mode`, etc.
Signed-off-by: Harshvardhan Karn <harshvkarn@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Which issue this PR fixes** *
fixes #57 #11 

**Special notes for your reviewer**:
Screenshot is added