### PR TITLE
Add all PV, PVC, and SC shape supports in backend

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -35,10 +35,10 @@ const (
 	ApplicationPod        = "applicationpod"
 
 	// Shapes used for different nodes
-	Circle   	   = "circle"
-	Triangle 	   = "triangle"
-	Square   	   = "square"
-	Pentagon 	   = "pentagon"
+	Circle         = "circle"
+	Triangle       = "triangle"
+	Square         = "square"
+	Pentagon       = "pentagon"
 	Hexagon        = "hexagon"
 	Heptagon       = "heptagon"
 	Octagon        = "octagon"

--- a/report/report.go
+++ b/report/report.go
@@ -35,14 +35,17 @@ const (
 	ApplicationPod        = "applicationpod"
 
 	// Shapes used for different nodes
-	Circle   = "circle"
-	Triangle = "triangle"
-	Square   = "square"
-	Pentagon = "pentagon"
-	Hexagon  = "hexagon"
-	Heptagon = "heptagon"
-	Octagon  = "octagon"
-	Cloud    = "cloud"
+	Circle   	   = "circle"
+	Triangle 	   = "triangle"
+	Square   	   = "square"
+	Pentagon 	   = "pentagon"
+	Hexagon        = "hexagon"
+	Heptagon       = "heptagon"
+	Octagon        = "octagon"
+	Cloud          = "cloud"
+	StorageSheet   = "storagesheet"
+	DottedCylinder = "dottedcylinder"
+	Cylinder       = "cylinder"
 
 	// Used when counting the number of containers
 	ContainersKey = "containers"
@@ -269,15 +272,15 @@ func MakeReport() Report {
 			WithLabel("service", "services"),
 
 		PersistentVolumeClaim: MakeTopology().
-			WithShape(Heptagon).
+			WithShape(DottedCylinder).
 			WithLabel("persistentvolumeclaim", "persistentvolumeclaims"),
 
 		PersistentVolume: MakeTopology().
-			WithShape(Heptagon).
+			WithShape(Cylinder).
 			WithLabel("persistentvolume", "persistentvolumes"),
 
 		StorageClass: MakeTopology().
-			WithShape(Triangle).
+			WithShape(StorageSheet).
 			WithLabel("storageclass", "storageclasses"),
 
 		ApplicationPod: MakeTopology().


### PR DESCRIPTION
**What this PR does / why we need it**:
   - Add `dottedcylinder` shape for `PersistentVolumeClaim`
   - Add `cylinder` shape for `PersistentVolume`
   - Add `sheet` shape for `StorageClass`
   Shapes will be visible in `PersistentVolume` subtopology

Signed-off-by: Harshvardhan Karn <harshvkarn@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->



**Which issue this PR fixes** 
 fixes: #62 
