### PR TITLE
Add details of Storage Class when clicked on any SC

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -32,6 +32,11 @@ const (
 	Status             = report.KubernetesStatus
 	Message            = report.KubernetesMessage
 	VolumeName         = report.KubernetesVolumeName
+	Provisioner        = report.KubernetesProvisioner
+	APIVersion         = report.KubernetesAPIVersion
+	UID                = report.KubernetesUID
+	ResourceVersion    = report.KubernetesResourceVersion
+	SelfLink           = report.KubernetesSelfLink
 )
 
 // Exposed for testing
@@ -129,8 +134,13 @@ var (
 	PersistentVolumeMetricTemplates = PodMetricTemplates
 
 	StorageClassMetadataTemplates = report.MetadataTemplates{
-		NodeType:  {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
-		Namespace: {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
+		NodeType:        {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
+		Name:            {ID: Name, Label: "Name", From: report.FromLatest, Priority: 2},
+		Provisioner:     {ID: Provisioner, Label: "Provisioner", From: report.FromLatest, Priority: 3},
+		APIVersion:      {ID: APIVersion, Label: "APIVersion", From: report.FromLatest, Priority: 4},
+		UID:             {ID: UID, Label: "UID", From: report.FromLatest, Priority: 5},
+		ResourceVersion: {ID: ResourceVersion, Label: "ResourceVersion", From: report.FromLatest, Priority: 6},
+		SelfLink:        {ID: SelfLink, Label: "SelfLink", From: report.FromLatest, Priority: 7},
 	}
 
 	StorageClassMetricTemplates = PodMetricTemplates

--- a/probe/kubernetes/storageclass.go
+++ b/probe/kubernetes/storageclass.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"encoding/json"
+
 	"github.com/weaveworks/scope/report"
 	storagev1 "k8s.io/api/storage/v1"
 )
@@ -17,6 +19,11 @@ type storageClass struct {
 	Meta
 }
 
+type apiversion struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+}
+
 // NewStorageClass returns new Storage Class type
 func NewStorageClass(p *storagev1.StorageClass) StorageClass {
 	return &storageClass{StorageClass: p, Meta: meta{p.ObjectMeta}}
@@ -24,9 +31,17 @@ func NewStorageClass(p *storagev1.StorageClass) StorageClass {
 
 // GetNode returns StorageClass as Node
 func (p *storageClass) GetNode(probeID string) report.Node {
+	var version apiversion
+	store := []byte(p.Annotations["kubectl.kubernetes.io/last-applied-configuration"])
+	json.Unmarshal(store, &version)
 	return p.MetaNode(report.MakeStorageClassNodeID(p.UID())).WithLatests(map[string]string{
 		report.ControlProbeID: probeID,
-		NodeType:              "StorageClass",
-		Namespace:             p.GetNamespace(),
+		NodeType:              version.Kind,
+		Name:                  p.GetName(),
+		Provisioner:           p.Provisioner,
+		APIVersion:            version.APIVersion,
+		UID:                   p.UID(),
+		ResourceVersion:       p.ResourceVersion,
+		SelfLink:              p.SelfLink,
 	})
 }

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -83,6 +83,11 @@ const (
 	KubernetesStatus               = "kubernetes_status"
 	KubernetesMessage              = "kubernetes_message"
 	KubernetesVolumeName           = "kubernetes_volume_name"
+	KubernetesProvisioner          = "kubernetes_provisioner"
+	KubernetesAPIVersion           = "kubernetes_apiVersion"
+	KubernetesUID                  = "kubernetes_uid"
+	KubernetesResourceVersion      = "kubernetes_resource_version"
+	KubernetesSelfLink             = "kubernetes_self_link"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
Signed-off-by: Chandan <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Add details about `Storage Class` in `node-details-content` when click on `Storage Class` inside `persistent Volume` tab.

- Storage Class details are like:- `Name`, `Provisioner`, `APIVersion`,etc.

**Which issue this PR fixes** : 

fixes #44 

**Special notes for your reviewer**:
- Added screenshot for reviewing.

![storageclass](https://user-images.githubusercontent.com/28861964/38043312-684ff372-32d4-11e8-83c5-56d9af65f351.png)
