### PR TITLE
Add application pods details when clicked on it

### DIFF
--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -37,6 +37,8 @@ const (
 	UID                = report.KubernetesUID
 	ResourceVersion    = report.KubernetesResourceVersion
 	SelfLink           = report.KubernetesSelfLink
+	Generation         = report.KubernetesGeneration
+	Kind               = report.KubernetesKind
 )
 
 // Exposed for testing
@@ -144,6 +146,24 @@ var (
 	}
 
 	StorageClassMetricTemplates = PodMetricTemplates
+
+	ApplicationPodMetadataTemplates = report.MetadataTemplates{
+
+		Kind:             {ID: Kind, Label: "Kind", From: report.FromLatest, Priority: 1},
+		IP:               {ID: IP, Label: "IP", From: report.FromLatest, Datatype: report.IP, Priority: 2},
+		State:            {ID: State, Label: "State", From: report.FromLatest, Priority: 3},
+		report.Container: {ID: report.Container, Label: "# Containers", From: report.FromCounters, Datatype: report.Number, Priority: 4},
+		Namespace:        {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 5},
+		Created:          {ID: Created, Label: "Created", From: report.FromLatest, Datatype: report.DateTime, Priority: 6},
+		VolumeClaimName:  {ID: VolumeClaimName, Label: "Claim Name", From: report.FromLatest, Priority: 7},
+		RestartCount:     {ID: RestartCount, Label: "Restart #", From: report.FromLatest, Priority: 8},
+		ResourceVersion:  {ID: ResourceVersion, Label: "Resource Version", From: report.FromLatest, Priority: 9},
+		APIVersion:       {ID: APIVersion, Label: "APIVersion", From: report.FromLatest, Priority: 10},
+		Generation:       {ID: Generation, Label: "Generation", From: report.FromLatest, Priority: 11},
+		UID:              {ID: UID, Label: "Uid", From: report.FromLatest, Priority: 12},
+	}
+
+	ApplicationPodMetricTemplates = docker.ContainerMetricTemplates
 
 	TableTemplates = report.TableTemplates{
 		LabelPrefix: {
@@ -637,8 +657,8 @@ func (r *Reporter) applicationPodTopology(probeID string) (report.Topology, []Ap
 	//TODO: Need to improve logic for topology.
 	var (
 		result = report.MakeTopology().
-			WithMetadataTemplates(PodMetadataTemplates).
-			WithMetricTemplates(PodMetricTemplates).
+			WithMetadataTemplates(ApplicationPodMetadataTemplates).
+			WithMetricTemplates(ApplicationPodMetricTemplates).
 			WithTableTemplates(TableTemplates)
 		ap = []ApplicationPod{}
 	)

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -88,6 +88,8 @@ const (
 	KubernetesUID                  = "kubernetes_uid"
 	KubernetesResourceVersion      = "kubernetes_resource_version"
 	KubernetesSelfLink             = "kubernetes_self_link"
+	KubernetesGeneration           = "kubernetes_generation"
+	KubernetesKind                 = "kubernetes_kind"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
Signed-off-by: Chandan <chandan.kr404@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Add details about `Application pods` in node-details-content when click on `Application pod` inside `Persistent Volume` tab..

- Application pod details are like:- `Kind`, `Reclaim Policy`, `APIVersion` `Generation` etc.

**Which issue this PR fixes**: 
fixes: https://github.com/openebs/scope/issues/66

**Special notes for your reviewer**:
- Add Screenshot for review.

![app](https://user-images.githubusercontent.com/28861964/38185303-2a35877e-366b-11e8-9ecb-88c20834e545.png)
