### PR TITLE
Fix circle.yaml for deployment of docker image.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -64,11 +64,12 @@ test:
     - docker tag weaveworks/scope:latest openebs/scope:ci
 
 deployment:
-  hub:
+  stag:
     branch: staging
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push openebs/scope:$(./tools/image-tag)
+  pro:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS


### PR DESCRIPTION
- In circle yaml different names should be given, if we are deploying different docker images to different branches.This PR fixes that issue.  


Signed-off-by: Pradeepkumarbk <pradeepkumar.bk96@gmail.com>