### PR TITLE
Add units for iops,latency and throughput

### DIFF
--- a/client/app/scripts/utils/string-utils.js
+++ b/client/app/scripts/utils/string-utils.js
@@ -50,6 +50,18 @@ function makeFormatters(renderFn) {
       return formatLargeValue(value);
     },
 
+    seconds(value) {
+      return renderFn(formatters.number(value), 's');
+    },
+
+    bytes(value) {
+      return renderFn(formatters.number(value), 'MB');
+    },
+
+    millisecond(value) {
+      return renderFn(formatters.number(value), 'ms');
+    },
+
     percent(value) {
       return renderFn(formatters.number(value), '%');
     }


### PR DESCRIPTION
Add units for iops,latency and throughput for plugin i.e 
- (s) for iops 
- (ms) for latency
- (MB) for throughput



Signed-off-by: Pradeepkumarbk <pradeepkumar.bk96@gmail.com>