### PR TITLE
Change case of ndmClient in import path

### DIFF
--- a/probe/kubernetes/client.go
+++ b/probe/kubernetes/client.go
@@ -9,7 +9,7 @@ import (
 	"github.com/weaveworks/common/backoff"
 
 	ndmv1alpha1 "github.com/openebs/node-disk-manager/pkg/apis/openebs.io/v1alpha1"
-	ndmClient "github.com/openebs/node-disk-manager/pkg/client/clientset/versioned"
+	ndmclient "github.com/openebs/node-disk-manager/pkg/client/clientset/versioned"
 	log "github.com/sirupsen/logrus"
 	apiappsv1beta1 "k8s.io/api/apps/v1beta1"
 	apibatchv1 "k8s.io/api/batch/v1"
@@ -56,7 +56,7 @@ type Client interface {
 type client struct {
 	quit                       chan struct{}
 	client                     *kubernetes.Clientset
-	ndmclient                  *ndmClient.Clientset
+	ndmClient                  *ndmclient.Clientset
 	podStore                   cache.Store
 	serviceStore               cache.Store
 	deploymentStore            cache.Store
@@ -138,7 +138,7 @@ func NewClient(config ClientConfig) (Client, error) {
 		return nil, err
 	}
 
-	nc, err := ndmClient.NewForConfig(restConfig)
+	nc, err := ndmclient.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func NewClient(config ClientConfig) (Client, error) {
 	result := &client{
 		quit:      make(chan struct{}),
 		client:    c,
-		ndmclient: nc,
+		ndmClient: nc,
 	}
 
 	result.podStore = NewEventStore(result.triggerPodWatches, cache.MetaNamespaceKeyFunc)
@@ -218,7 +218,7 @@ func (c *client) clientAndType(resource string) (rest.Interface, interface{}, er
 		return c.client.AppsV1beta1().RESTClient(), &apiappsv1beta1.StatefulSet{}, nil
 	case "disks":
 		//ToDo: implement isResourceSupported to avoid any runtime panic
-		return c.ndmclient.OpenebsV1alpha1().RESTClient(), &ndmv1alpha1.Disk{}, nil
+		return c.ndmClient.OpenebsV1alpha1().RESTClient(), &ndmv1alpha1.Disk{}, nil
 	case "cronjobs":
 		ok, err := c.isResourceSupported(c.client.BatchV1beta1().RESTClient().APIVersion(), resource)
 		if err != nil {


### PR DESCRIPTION
- In import path, scope uses small alphabets to use any dependency
but ndm dependency is defined in CamelCase.

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>