### PR TITLE
Add cStor PV-controller adjacency

### DIFF
--- a/probe/kubernetes/disk.go
+++ b/probe/kubernetes/disk.go
@@ -36,6 +36,6 @@ func (p *disk) GetNode() report.Node {
 		Serial:            p.Spec.Details.Serial,
 		SpcVersion:        p.Spec.Details.SPCVersion,
 		Vendor:            p.Spec.Details.Vendor,
-		Label:             p.GetLabels()["kubernetes.io/hostname"],
+		HostName:          p.GetLabels()["kubernetes.io/hostname"],
 	})
 }

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -18,38 +18,39 @@ import (
 
 // These constants are keys used in node metadata
 const (
-	IP                 = report.KubernetesIP
-	ObservedGeneration = report.KubernetesObservedGeneration
-	Replicas           = report.KubernetesReplicas
-	DesiredReplicas    = report.KubernetesDesiredReplicas
-	NodeType           = report.KubernetesNodeType
-	Model              = report.KubernetesModel
-	LogicalSectorSize  = report.KubernetesLogicalSectorSize
-	Storage            = report.KubernetesStorage
-	FirmwareRevision   = report.KubernetesFirmwareRevision
-	Serial             = report.KubernetesSerial
-	SpcVersion         = report.KubernetesSpcVersion
-	Vendor             = report.KubernetesVendor
-	DiskList           = report.KubernetesDiskList
-	MaxPools           = report.KubernetesMaxPools
-	APIVersion         = report.KubernetesAPIVersion
-	Value              = report.KubernetesValue
-	Label              = report.KubernetesLabel
-	Type               = report.KubernetesType
-	Ports              = report.KubernetesPorts
-	VolumeClaim        = report.KubernetesVolumeClaim
-	StorageClassName   = report.KubernetesStorageClassName
-	DiskName           = report.KubernetesDiskName
-	PoolName           = report.KubernetesPoolName
-	PoolClaim          = report.KubernetesPoolClaim
-	AccessModes        = report.KubernetesAccessModes
-	ReclaimPolicy      = report.KubernetesReclaimPolicy
-	Status             = report.KubernetesStatus
-	Message            = report.KubernetesMessage
-	VolumeName         = report.KubernetesVolumeName
-	Provisioner        = report.KubernetesProvisioner
-	VolumeSnapshotName = report.KubernetesVolumeSnapshotName
-	SnapshotData       = report.KubernetesSnapshotData
+	IP                   = report.KubernetesIP
+	ObservedGeneration   = report.KubernetesObservedGeneration
+	Replicas             = report.KubernetesReplicas
+	DesiredReplicas      = report.KubernetesDesiredReplicas
+	NodeType             = report.KubernetesNodeType
+	Model                = report.KubernetesModel
+	LogicalSectorSize    = report.KubernetesLogicalSectorSize
+	Storage              = report.KubernetesStorage
+	FirmwareRevision     = report.KubernetesFirmwareRevision
+	Serial               = report.KubernetesSerial
+	SpcVersion           = report.KubernetesSpcVersion
+	Vendor               = report.KubernetesVendor
+	DiskList             = report.KubernetesDiskList
+	MaxPools             = report.KubernetesMaxPools
+	APIVersion           = report.KubernetesAPIVersion
+	Value                = report.KubernetesValue
+	StoragePoolClaimName = report.KubernetesStoragePoolClaimName
+	Type                 = report.KubernetesType
+	Ports                = report.KubernetesPorts
+	VolumeClaim          = report.KubernetesVolumeClaim
+	StorageClassName     = report.KubernetesStorageClassName
+	DiskName             = report.KubernetesDiskName
+	PoolName             = report.KubernetesPoolName
+	PoolClaim            = report.KubernetesPoolClaim
+	AccessModes          = report.KubernetesAccessModes
+	ReclaimPolicy        = report.KubernetesReclaimPolicy
+	Status               = report.KubernetesStatus
+	Message              = report.KubernetesMessage
+	VolumeName           = report.KubernetesVolumeName
+	Provisioner          = report.KubernetesProvisioner
+	VolumeSnapshotName   = report.KubernetesVolumeSnapshotName
+	SnapshotData         = report.KubernetesSnapshotData
+	HostName             = report.KubernetesHostName
 )
 
 // Exposed for testing
@@ -160,6 +161,7 @@ var (
 	StoragePoolMetadataTemplates = report.MetadataTemplates{
 		NodeType:   {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
 		APIVersion: {ID: APIVersion, Label: "API Version", From: report.FromLatest, Priority: 2},
+		DiskList:   {ID: DiskList, Label: "Disks", From: report.FromLatest, Priority: 3},
 	}
 
 	StoragePoolClaimMetadataTemplates = report.MetadataTemplates{

--- a/probe/kubernetes/storagepool.go
+++ b/probe/kubernetes/storagepool.go
@@ -1,14 +1,23 @@
 package kubernetes
 
 import (
+	"strings"
+
 	mayav1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 
 	"github.com/weaveworks/scope/report"
 )
 
+// Labels key for StoragePool
+const (
+	StoragePoolClaimLabel    = "openebs.io/storage-pool-claim"
+	OldStoragePoolClaimLabel = "openebs.io/storagepoolclaim"
+)
+
 // StoragePool represent StoragePool interface
 type StoragePool interface {
 	Meta
+	GetStoragePoolClaimName() string
 	GetNode() report.Node
 }
 
@@ -23,11 +32,20 @@ func NewStoragePool(p *mayav1alpha1.StoragePool) StoragePool {
 	return &storagePool{StoragePool: p, Meta: meta{p.ObjectMeta}}
 }
 
+func (p *storagePool) GetStoragePoolClaimName() string {
+	labels := p.GetLabels()
+	if storagePoolClaimName, ok := labels[StoragePoolClaimLabel]; ok {
+		return storagePoolClaimName
+	}
+	return labels[OldStoragePoolClaimLabel]
+}
+
 // GetNode returns StoragePool as Node
 func (p *storagePool) GetNode() report.Node {
 	return p.MetaNode(report.MakeStoragePoolNodeID(p.UID())).WithLatests(map[string]string{
-		NodeType:   "Storage Pool",
-		APIVersion: p.APIVersion,
-		Label:      p.GetLabels()["openebs.io/storagepoolclaim"],
+		NodeType:             "Storage Pool",
+		APIVersion:           p.APIVersion,
+		DiskList:             strings.Join(p.Spec.Disks.DiskList, "/"),
+		StoragePoolClaimName: p.GetStoragePoolClaimName(),
 	})
 }

--- a/probe/kubernetes/storagepoolclaim.go
+++ b/probe/kubernetes/storagepoolclaim.go
@@ -4,7 +4,6 @@ import (
 	mayav1alpha1 "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
 
 	"strconv"
-	"strings"
 
 	"github.com/weaveworks/scope/report"
 )
@@ -31,7 +30,6 @@ func (p *storagePoolClaim) GetNode() report.Node {
 	return p.MetaNode(report.MakeStoragePoolClaimNodeID(p.UID())).WithLatests(map[string]string{
 		NodeType:   "Storage Pool Claim",
 		APIVersion: p.APIVersion,
-		DiskList:   strings.Join(p.Spec.Disks.DiskList, "/"),
 		MaxPools:   strconv.Itoa(int(p.Spec.MaxPools)),
 		Status:     p.Status.Phase,
 	})

--- a/probe/kubernetes/volumesnapshot.go
+++ b/probe/kubernetes/volumesnapshot.go
@@ -7,7 +7,7 @@ import (
 
 // SnapshotPVName is the label key which provides PV name
 const (
-	SnapshotPVName = "SnapshotMetadata-PVName"
+	SnapshotPVNameLabel = "SnapshotMetadata-PVName"
 )
 
 // VolumeSnapshot represent kubernetes VolumeSnapshot interface
@@ -34,6 +34,6 @@ func (p *volumeSnapshot) GetNode(probeID string) report.Node {
 		NodeType:              "Volume Snapshot",
 		VolumeClaim:           p.Spec.PersistentVolumeClaimName,
 		SnapshotData:          p.Spec.SnapshotDataName,
-		VolumeName:            p.GetLabels()[SnapshotPVName],
+		VolumeName:            p.GetLabels()[SnapshotPVNameLabel],
 	}).WithLatestActiveControls(CloneVolumeSnapshot, DeleteVolumeSnapshot)
 }

--- a/render/host.go
+++ b/render/host.go
@@ -76,7 +76,7 @@ func (v ndmRenderer) Render(rpt report.Report) Nodes {
 			hostid := strings.Split(hostName, ";")
 			hostName = hostid[0]
 			for diskNode, d := range rpt.Disk.Nodes {
-				Label, _ := d.Latest.Lookup(kubernetes.Label)
+				Label, _ := d.Latest.Lookup(kubernetes.HostName)
 				if strings.ToLower(hostName) == Label {
 					h.Adjacency = h.Adjacency.Add(d.ID)
 					h.Children = h.Children.Add(d)

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -86,7 +86,7 @@ const (
 	KubernetesMaxPools                    = "kubernetes_max_pools"
 	KubernetesValue                       = "kubernetes_value"
 	KubernetesAPIVersion                  = "kubernetes_api_version"
-	KubernetesLabel                       = "kubernetes_label"
+	KubernetesStoragePoolClaimName        = "kubernetes_storage_pool_claim_name"
 	KubernetesDiskName                    = "kubernetes_disk_name"
 	KubernetesPoolName                    = "kubernetes_pool_name"
 	KubernetesPoolClaim                   = "kubernetes_pool_claim_name"
@@ -101,6 +101,7 @@ const (
 	KubernetesCreateVolumeSnapshot        = "kubernetes_create_volume_snapshot"
 	KubernetesCloneVolumeSnapshot         = "kubernetes_clone_volume_snapshot"
 	KubernetesDeleteVolumeSnapshot        = "kubernetes_delete_volume_snapshot"
+	KubernetesHostName                    = "kubernetes_host_name"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
- This commit will add support for PV-controller adjacency for cStor
earlier, we were using Pod name to make this adjacency but now this is
changed to labels

        Controller pod has a label for fetching the PV name.
        In current version of OpenEBS i.e. 0.7, label is
        `openebs.io/persistent-volume`
        In older versions of OpenEBS, label is `vsm`

        For jiva, replica pods will also have the same label,
        ignoring them if the Pod name contains `-rep-`

- Change logic for adding adjacency of SP -> Disk

        Earlier SPC contains the disk list but in the recent changes,
        SP will have disk list.

        Now, disk list is fetched in SP, and the same will be used to
        create an adjacency between SP and Disk

- Change label name from `Label` to `HostName` in disk.go

- Change label name in volumeSnapshot.go

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>

Changes committed:

         modified:   probe/kubernetes/disk.go
         modified:   probe/kubernetes/pod.go
         modified:   probe/kubernetes/reporter.go
         modified:   probe/kubernetes/storagepool.go
         modified:   probe/kubernetes/storagepoolclaim.go
         modified:   probe/kubernetes/volumesnapshot.go
         modified:   render/host.go
         modified:   render/persistentvolume.go
         modified:   report/map_keys.go