### PR TITLE
import missing terminal.scss in contrast.scss

### DIFF
--- a/client/app/styles/contrast.scss
+++ b/client/app/styles/contrast.scss
@@ -1,3 +1,4 @@
 @import "variables";
 @import "contrast-overrides";
 @import "base";
+@import "terminal";


### PR DESCRIPTION
Add terminal.scss in contrast.scss which is missing currently and causing the terminal styling in contrast mode. 

Before:
<img width="372" alt="screen shot 2018-09-14 at 12 09 19 pm" src="https://user-images.githubusercontent.com/18216179/45542437-80e0f400-b82f-11e8-864e-3172af9e6ea7.png">

After:
<img width="520" alt="screen shot 2018-09-14 at 3 03 03 pm" src="https://user-images.githubusercontent.com/18216179/45542468-98b87800-b82f-11e8-97ab-6006bbe395bb.png">
