### PR TITLE
Add storage and volume sub-topology under Hosts

### DIFF
--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -297,6 +297,12 @@ func MakeRegistry() *Registry {
 			Name:     "Hosts",
 			Rank:     4,
 		},
+		// APITopologyDesc{
+		// 	id:       weaveID,
+		// 	parent:   hostsID,
+		// 	renderer: render.WeaveRenderer,
+		// 	Name:     "Weave Net",
+		// },
 		APITopologyDesc{
 			id:          storageID,
 			parent:      hostsID,

--- a/app/api_topologies.go
+++ b/app/api_topologies.go
@@ -31,6 +31,8 @@ const (
 	podsID                 = "pods"
 	kubeControllersID      = "kube-controllers"
 	servicesID             = "services"
+	volumesID              = "volumes"
+	storageID              = "storage"
 	hostsID                = "hosts"
 	weaveID                = "weave"
 	ecsTasksID             = "ecs-tasks"
@@ -246,7 +248,7 @@ func MakeRegistry() *Registry {
 			renderer:    render.PodRenderer,
 			Name:        "Pods",
 			Rank:        3,
-			Options:     []APITopologyOptionGroup{snapshotFilter, storageFilter, unmanagedFilter},
+			Options:     []APITopologyOptionGroup{unmanagedFilter},
 			HideIfEmpty: true,
 		},
 		APITopologyDesc{
@@ -296,10 +298,20 @@ func MakeRegistry() *Registry {
 			Rank:     4,
 		},
 		APITopologyDesc{
-			id:       weaveID,
-			parent:   hostsID,
-			renderer: render.WeaveRenderer,
-			Name:     "Weave Net",
+			id:          storageID,
+			parent:      hostsID,
+			renderer:    render.KubernetesStorageRenderer,
+			Name:        "Storage",
+			Options:     []APITopologyOptionGroup{},
+			HideIfEmpty: true,
+		},
+		APITopologyDesc{
+			id:          volumesID,
+			parent:      hostsID,
+			renderer:    render.KubernetesVolumesRenderer,
+			Name:        "Volumes",
+			Options:     []APITopologyOptionGroup{snapshotFilter, unmanagedFilter},
+			HideIfEmpty: true,
 		},
 	)
 

--- a/probe/kubernetes/reporter.go
+++ b/probe/kubernetes/reporter.go
@@ -52,6 +52,7 @@ const (
 	SnapshotData         = report.KubernetesSnapshotData
 	HostName             = report.KubernetesHostName
 	StorageDriver        = report.KubernetesStorageDriver
+	VolumePod            = report.KubernetesVolumePod
 )
 
 // Exposed for testing
@@ -175,7 +176,7 @@ var (
 
 	VolumeSnapshotMetadataTemplates = report.MetadataTemplates{
 		NodeType:     {ID: NodeType, Label: "Type", From: report.FromLatest, Priority: 1},
-		Namespace:    {ID: Namespace, Label: "Name", From: report.FromLatest, Priority: 2},
+		Namespace:    {ID: Namespace, Label: "Namespace", From: report.FromLatest, Priority: 2},
 		VolumeClaim:  {ID: VolumeClaim, Label: "Persistent volume claim", From: report.FromLatest, Priority: 3},
 		SnapshotData: {ID: SnapshotData, Label: "Volume snapshot data", From: report.FromLatest, Priority: 4},
 		VolumeName:   {ID: VolumeName, Label: "Persistent volume", From: report.FromLatest, Priority: 5},

--- a/render/detailed/summary.go
+++ b/render/detailed/summary.go
@@ -105,12 +105,14 @@ var primaryAPITopology = map[string]string{
 	report.ECSService:            "ecs-services",
 	report.SwarmService:          "swarm-services",
 	report.Host:                  "hosts",
-	report.PersistentVolume:      "pods",
-	report.PersistentVolumeClaim: "pods",
-	report.StorageClass:          "pods",
+	report.PersistentVolume:      "volumes",
+	report.PersistentVolumeClaim: "volumes",
+	report.StorageClass:          "volumes",
 	report.Disk:                  "hosts",
-	report.VolumeSnapshot:        "pods",
-	report.VolumeSnapshotData:    "pods",
+	report.VolumeSnapshot:        "volumes",
+	report.VolumeSnapshotData:    "volumes",
+	report.StoragePoolClaim:      "storage",
+	report.StoragePool:           "storage",
 }
 
 // MakeBasicNodeSummary returns a basic summary of a node, if
@@ -387,41 +389,49 @@ func weaveNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 
 func persistentVolumeNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "persistent volume"
 	return base
 }
 
 func persistentVolumeClaimNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "persistent volume claim"
 	return base
 }
 
 func storageClassNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "storage class"
 	return base
 }
 
 func diskNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "disk"
 	return base
 }
 
 func storagePoolNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "storage pool"
 	return base
 }
 
 func volumeSnapshotNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "volume snapshot"
 	return base
 }
 
 func storagePoolClaimNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "storage pool claim"
 	return base
 }
 
 func volumeSnapshotDataNodeSummary(base BasicNodeSummary, n report.Node) BasicNodeSummary {
 	base = addKubernetesLabelAndRank(base, n)
+	base.LabelMinor = "volume snapshot data"
 	return base
 }
 

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -3,7 +3,6 @@ package expected
 import (
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/host"
-	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
@@ -271,34 +270,6 @@ var (
 				RenderedProcesses[fixture.ServerProcessNodeID],
 				RenderedContainers[fixture.ServerContainerNodeID],
 			)),
-
-		fixture.PersistentVolumeClaimNodeID: persistentVolumeClaim(fixture.PersistentVolumeClaimNodeID, fixture.PersistentVolumeNodeID).
-			WithLatests(map[string]string{
-				kubernetes.Name:             "pvc-6124",
-				kubernetes.Namespace:        "ping",
-				kubernetes.Status:           "bound",
-				kubernetes.VolumeName:       "pongvolume",
-				kubernetes.AccessModes:      "ReadWriteOnce",
-				kubernetes.StorageClassName: "standard",
-			}).WithChild(report.MakeNode(fixture.PersistentVolumeNodeID).WithTopology(report.PersistentVolume)),
-
-		fixture.PersistentVolumeNodeID: persistentVolume(fixture.PersistentVolumeNodeID).
-			WithLatests(map[string]string{
-				kubernetes.Name:             "pongvolume",
-				kubernetes.Namespace:        "ping",
-				kubernetes.Status:           "bound",
-				kubernetes.VolumeClaim:      "pvc-6124",
-				kubernetes.AccessModes:      "ReadWriteOnce",
-				kubernetes.StorageClassName: "standard",
-				kubernetes.StorageDriver:    "iSCSI",
-			}),
-
-		fixture.StorageClassNodeID: StorageClass(fixture.StorageClassNodeID, fixture.PersistentVolumeClaimNodeID).
-			WithLatests(map[string]string{
-				kubernetes.Name:        "standard",
-				kubernetes.Provisioner: "pong",
-			}).WithChild(report.MakeNode(fixture.PersistentVolumeClaimNodeID).WithTopology(report.PersistentVolumeClaim)),
-
 		UnmanagedServerID:         unmanagedServerNode,
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerPodNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,

--- a/render/expected/expected.go
+++ b/render/expected/expected.go
@@ -3,6 +3,7 @@ package expected
 import (
 	"github.com/weaveworks/scope/probe/docker"
 	"github.com/weaveworks/scope/probe/host"
+	"github.com/weaveworks/scope/probe/kubernetes"
 	"github.com/weaveworks/scope/probe/process"
 	"github.com/weaveworks/scope/render"
 	"github.com/weaveworks/scope/report"
@@ -270,6 +271,7 @@ var (
 				RenderedProcesses[fixture.ServerProcessNodeID],
 				RenderedContainers[fixture.ServerContainerNodeID],
 			)),
+
 		UnmanagedServerID:         unmanagedServerNode,
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerPodNodeID),
 		render.OutgoingInternetID: theOutgoingInternetNode,
@@ -326,6 +328,38 @@ var (
 		// UnknownPseudoNode1ID:      unknownPseudoNode1(fixture.ServerHostNodeID),
 		// UnknownPseudoNode2ID:      unknownPseudoNode2(fixture.ServerHostNodeID),
 		render.IncomingInternetID: theIncomingInternetNode(fixture.ServerHostNodeID),
+		render.OutgoingInternetID: theOutgoingInternetNode,
+	}
+	RenderedKubernetesVolumes = report.Nodes{
+		fixture.PersistentVolumeClaimNodeID: persistentVolumeClaim(fixture.PersistentVolumeClaimNodeID, fixture.PersistentVolumeNodeID).
+			WithLatests(map[string]string{
+				kubernetes.Name:             "pvc-6124",
+				kubernetes.Namespace:        "ping",
+				kubernetes.Status:           "bound",
+				kubernetes.VolumeName:       "pongvolume",
+				kubernetes.AccessModes:      "ReadWriteOnce",
+				kubernetes.StorageClassName: "standard",
+			}).WithChild(report.MakeNode(fixture.PersistentVolumeNodeID).WithTopology(report.PersistentVolume)),
+
+		fixture.PersistentVolumeNodeID: persistentVolume(fixture.PersistentVolumeNodeID).
+			WithLatests(map[string]string{
+				kubernetes.Name:             "pongvolume",
+				kubernetes.Namespace:        "ping",
+				kubernetes.Status:           "bound",
+				kubernetes.VolumeClaim:      "pvc-6124",
+				kubernetes.AccessModes:      "ReadWriteOnce",
+				kubernetes.StorageClassName: "standard",
+				kubernetes.StorageDriver:    "iSCSI",
+			}),
+
+		fixture.StorageClassNodeID: StorageClass(fixture.StorageClassNodeID, fixture.PersistentVolumeClaimNodeID).
+			WithLatests(map[string]string{
+				kubernetes.Name:        "standard",
+				kubernetes.Provisioner: "pong",
+			}).WithChild(report.MakeNode(fixture.PersistentVolumeClaimNodeID).WithTopology(report.PersistentVolumeClaim)),
+
+		UnmanagedServerID:         unmanagedServerNode,
+		render.IncomingInternetID: theIncomingInternetNode(),
 		render.OutgoingInternetID: theOutgoingInternetNode,
 	}
 )

--- a/render/persistentvolume_test.go
+++ b/render/persistentvolume_test.go
@@ -1,0 +1,20 @@
+package render_test
+
+import (
+	"testing"
+
+	"github.com/weaveworks/common/test"
+	"github.com/weaveworks/scope/render"
+	"github.com/weaveworks/scope/render/expected"
+	"github.com/weaveworks/scope/test/fixture"
+	"github.com/weaveworks/scope/test/reflect"
+	"github.com/weaveworks/scope/test/utils"
+)
+
+func TestKubernetesVolumesRenderer(t *testing.T) {
+	have := utils.Prune(render.KubernetesVolumesRenderer.Render(fixture.Report).Nodes)
+	want := utils.Prune(expected.RenderedKubernetesVolumes)
+	if !reflect.DeepEqual(want, have) {
+		t.Error(test.Diff(want, have))
+	}
+}

--- a/render/pod.go
+++ b/render/pod.go
@@ -66,7 +66,6 @@ var PodRenderer = Memoise(ConditionalRenderer(renderKubernetesTopologies,
 					)},
 			),
 			ConnectionJoin(MapPod2IP, report.Pod),
-			KubernetesVolumesRenderer,
 		),
 	),
 ))

--- a/render/storagerenderer.go
+++ b/render/storagerenderer.go
@@ -1,0 +1,76 @@
+package render
+
+import (
+	"strings"
+
+	"github.com/weaveworks/scope/probe/kubernetes"
+	"github.com/weaveworks/scope/report"
+)
+
+// KubernetesStorageRenderer is a Renderer which combines all Kubernetes
+// storage components such as storage pools, storage pool claims and disks.
+var KubernetesStorageRenderer = MakeReduce(
+	PVCToStorageClassRenderer,
+	SPCToSPRenderer,
+	SPToDiskRenderer,
+)
+
+// SPCToSPRenderer is a Renderer which produces a renderable kubernetes CRD SPC
+var SPCToSPRenderer = spcToSpRenderer{}
+
+// spcToSpRenderer is a Renderer to render SPC & SP nodes.
+type spcToSpRenderer struct{}
+
+// Render renders the SPC & SP nodes with adjacency.
+// Here we are obtaining the spc name from sp and adjacency is created by matching it with spc name.
+func (v spcToSpRenderer) Render(rpt report.Report) Nodes {
+	nodes := make(report.Nodes)
+	for spcID, spcNode := range rpt.StoragePoolClaim.Nodes {
+		spcName, _ := spcNode.Latest.Lookup(kubernetes.Name)
+		for _, spNode := range rpt.StoragePool.Nodes {
+			spcNameFromLatest, _ := spNode.Latest.Lookup(kubernetes.StoragePoolClaimName)
+			if spcName == spcNameFromLatest {
+				spcNode.Adjacency = spcNode.Adjacency.Add(spNode.ID)
+				spcNode.Children = spcNode.Children.Add(spNode)
+			}
+		}
+		nodes[spcID] = spcNode
+	}
+	return Nodes{Nodes: nodes}
+}
+
+// SPToDiskRenderer is a Renderer which produces a renderable kubernetes CRD Disk
+var SPToDiskRenderer = spToDiskRenderer{}
+
+// spToDiskRenderer is a Renderer to render SP & Disk .
+type spToDiskRenderer struct{}
+
+// Render renders the SP & Disk nodes with adjacency.
+func (v spToDiskRenderer) Render(rpt report.Report) Nodes {
+	var disks []string
+	nodes := make(report.Nodes)
+	for spID, spNode := range rpt.StoragePool.Nodes {
+		disk, _ := spNode.Latest.Lookup(kubernetes.DiskList)
+		if strings.Contains(disk, "/") {
+			disks = strings.Split(disk, "/")
+		} else {
+			disks = []string{disk}
+		}
+
+		diskList := make(map[string]string)
+		for _, disk := range disks {
+			diskList[disk] = disk
+		}
+
+		for diskID, diskNode := range rpt.Disk.Nodes {
+			diskName, _ := diskNode.Latest.Lookup(kubernetes.Name)
+			if diskName == diskList[diskName] {
+				spNode.Adjacency = spNode.Adjacency.Add(diskNode.ID)
+				spNode.Children = spNode.Children.Add(diskNode)
+			}
+			nodes[diskID] = diskNode
+		}
+		nodes[spID] = spNode
+	}
+	return Nodes{Nodes: nodes}
+}

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -103,6 +103,7 @@ const (
 	KubernetesDeleteVolumeSnapshot        = "kubernetes_delete_volume_snapshot"
 	KubernetesHostName                    = "kubernetes_host_name"
 	KubernetesStorageDriver               = "kubernetes_storage_driver"
+	KubernetesVolumePod                   = "kubernetes_volume_pod"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
- Storage sub-topology will show SP, SPC, SC, and disk.

- Volume sub-topology will show PV, PVC, applications pods,
controller/target and replica pods.

- Add name and namespace in volume snapshot.

- Add LabelMinor to storage resources.

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>