### PR TITLE
Fix UI blankout issue

### DIFF
--- a/render/persistentvolume.go
+++ b/render/persistentvolume.go
@@ -144,7 +144,9 @@ func (v pvToControllerRenderer) Render(rpt report.Report) Nodes {
 				p.Children = p.Children.Add(volumeSnapshotNode)
 			}
 		}
-		nodes[pvNodeID] = p
+		if p.ID != "" {
+			nodes[pvNodeID] = p
+		}
 	}
 	return Nodes{Nodes: nodes}
 }


### PR DESCRIPTION
- This was happening because the plugin is sending report of a node
which has no ID and description and the renderer is rendering that also.

This change will exclude all the PVs which has empty ID.

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>