### PR TITLE
Add support for zen mode in scope

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -197,7 +197,7 @@ class App extends React.Component {
     const {
       isTableViewMode, isGraphViewMode, isResourceViewMode, showingDetails,
       showingHelp, showingNetworkSelector, showingTroubleshootingMenu,
-      timeTravelTransitioning, timeTravelSupported, contrastMode,
+      timeTravelTransitioning, timeTravelSupported, contrastMode, zenMode
     } = this.props;
 
     const className = classNames('scope-app', {
@@ -209,7 +209,7 @@ class App extends React.Component {
       <ThemeProvider theme={{...commonTheme, scope: contrastMode ? contrastTheme : defaultTheme }}>
         <>
           <GlobalStyle />
-
+.0
           <div className={className} ref={this.saveAppRef}>
             {showingDebugToolbar() && <DebugToolbar />}
 
@@ -222,27 +222,30 @@ class App extends React.Component {
               renderNodeDetailsExtras={this.props.renderNodeDetailsExtras}
             />
             )}
+            {!zenMode && (
+              <div className="header">
+                {timeTravelSupported && this.props.renderTimeTravel()}
 
-            <div className="header">
-              {timeTravelSupported && this.props.renderTimeTravel()}
-
-              <div className="selectors">
-                <Search />
-                <Topologies />
-                <ViewModeSelector />
-                <TimeControl />
+                <div className="selectors">
+                  <Search />
+                  <Topologies />
+                  <ViewModeSelector />
+                  <TimeControl />
+                </div>
               </div>
-            </div>
+            )}
 
             <Nodes />
 
+            {!zenMode && (
             <Sidebar classNames={isTableViewMode ? 'sidebar-gridmode' : ''}>
               {showingNetworkSelector && isGraphViewMode && <NetworkSelector />}
               {!isResourceViewMode && <Status />}
               {!isResourceViewMode && <TopologyOptions />}
             </Sidebar>
+            )}
 
-            <Footer />
+            {!zenMode && <Footer />}
 
             <Overlay faded={timeTravelTransitioning} />
           </div>
@@ -271,7 +274,8 @@ function mapStateToProps(state) {
     timeTravelSupported: timeTravelSupportedSelector(state),
     timeTravelTransitioning: state.get('timeTravelTransitioning'),
     topologyViewMode: state.get('topologyViewMode'),
-    urlState: getUrlState(state)
+    urlState: getUrlState(state),
+    zenMode: state.get('zenMode'),
   };
 }
 

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -698,6 +698,11 @@ export function rootReducer(state = initialState, action) {
       if (action.state.contrastMode !== undefined) {
         state = state.set('contrastMode', action.state.contrastMode);
       }
+      // zenMode is if the value of this flag is true, scope will render only the topology
+      // in the canvas. Header, footer, and sider will be disabled.
+      // default: false
+      // @example: 
+      //    http://<ip>:<port>/#!/state/{"topologyId":"pods","topologyOptions":{"hosts":{"snapshot":["show"]}},"zenMode":true} 
       if (action.state.zenMode !== undefined) {
         state = state.set('zenMode', action.state.zenMode);
       }

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -93,6 +93,7 @@ export const initialState = makeMap({
   // Set some initial numerical values to prevent NaN in case of edgy race conditions.
   viewport: makeMap({ height: 0, width: 0 }),
   websocketClosed: false,
+  zenMode: false,
   zoomCache: makeMap(),
 });
 
@@ -696,6 +697,9 @@ export function rootReducer(state = initialState, action) {
       }
       if (action.state.contrastMode !== undefined) {
         state = state.set('contrastMode', action.state.contrastMode);
+      }
+      if (action.state.zenMode !== undefined) {
+        state = state.set('zenMode', action.state.zenMode);
       }
       if (action.state.showingNetworks) {
         state = state.set('showingNetworks', action.state.showingNetworks);

--- a/client/app/scripts/reducers/root.js
+++ b/client/app/scripts/reducers/root.js
@@ -701,8 +701,8 @@ export function rootReducer(state = initialState, action) {
       // zenMode is if the value of this flag is true, scope will render only the topology
       // in the canvas. Header, footer, and sider will be disabled.
       // default: false
-      // @example: 
-      //    http://<ip>:<port>/#!/state/{"topologyId":"pods","topologyOptions":{"hosts":{"snapshot":["show"]}},"zenMode":true} 
+      // @example:
+      //    http://<ip>:<port>/#!/state/{"topologyId":"pods","topologyOptions":{"hosts":{"snapshot":["show"]}},"zenMode":true}
       if (action.state.zenMode !== undefined) {
         state = state.set('zenMode', action.state.zenMode);
       }

--- a/client/app/scripts/utils/router-utils.js
+++ b/client/app/scripts/utils/router-utils.js
@@ -99,6 +99,7 @@ export function getUrlState(state) {
     topologyId: state.get('currentTopologyId'),
     topologyOptions: topologyOptionsDiff,
     topologyViewMode: state.get('topologyViewMode'),
+    zenMode: state.get('zenMode'),
   };
 
   if (state.get('showingNetworks')) {


### PR DESCRIPTION
zenMode: This is the mode where scope will render just the topology, no
header and footer, ideal for scope with smaller iframe(embedded frames)

- Add a flag `zenMode` and read from URL
- (future-scope): Add support for keyboard shortcut to toggle

**Without ZenMode**
![image](https://user-images.githubusercontent.com/18168330/74011619-4c368500-49ae-11ea-93fe-7833ba082d4e.png)
**With ZenMode**
![image](https://user-images.githubusercontent.com/18168330/74011668-6bcdad80-49ae-11ea-95a5-7204ed885229.png)

Signed-off-by: ibreakthecloud <harshvardhan.karn@mayadata.io>