### PR TITLE
zenMode should have ViewModeSelector option

### DIFF
--- a/client/app/scripts/components/app.js
+++ b/client/app/scripts/components/app.js
@@ -221,18 +221,16 @@ class App extends React.Component {
               renderNodeDetailsExtras={this.props.renderNodeDetailsExtras}
             />
             )}
-            {!zenMode && (
-              <div className="header">
-                {timeTravelSupported && this.props.renderTimeTravel()}
+            <div className="header">
+              {timeTravelSupported && this.props.renderTimeTravel()}
 
-                <div className="selectors">
-                  <Search />
-                  <Topologies />
-                  <ViewModeSelector />
-                  <TimeControl />
-                </div>
+              <div className="selectors">
+                {!zenMode && <Search />}
+                {!zenMode && <Topologies />}
+                <ViewModeSelector />
+                {!zenMode && <TimeControl />}
               </div>
-            )}
+            </div>
 
             <Nodes />
 


### PR DESCRIPTION
zenMode was removing everything but the graph and the table.
This PR is suppose to bring back the ViewModeSelector option to select
the table or the graph. On zenMode true and false both, option to change
the canvas from table to graph and vice versa will still be there.

`zenMode: true`

![image](https://user-images.githubusercontent.com/18168330/74846725-fde29800-5356-11ea-9f05-d1c48a9bc337.png)


`zenMode: false`
![image](https://user-images.githubusercontent.com/18168330/74846686-eb685e80-5356-11ea-95b4-780fb1efe701.png)

Signed-off-by: ibreakthecloud <harshvardhan.karn@mayadata.io>