### PR TITLE
Add k8s node name in hosts metadata

### DIFF
--- a/probe/host/reporter_test.go
+++ b/probe/host/reporter_test.go
@@ -74,6 +74,7 @@ func TestReporter(t *testing.T) {
 	}{
 		{host.Timestamp, timestamp.UTC().Format(time.RFC3339Nano)},
 		{host.HostName, hostname},
+		{host.NodeName, hostname},
 		{host.OS, runtime.GOOS},
 		{host.Uptime, uptime},
 		{host.KernelVersion, kernel},

--- a/report/map_keys.go
+++ b/report/map_keys.go
@@ -136,6 +136,7 @@ const (
 	KubernetesFreeSize                     = "kubernetes_free_size"
 	KubernetesUsedSize                     = "kubernetes_used_size"
 	KubernetesCStorPoolInstanceUID         = "kubernetes_cstor_pool_instance"
+	KubernetesNodeName                     = "kubernetes_node_name"
 	// probe/awsecs
 	ECSCluster             = "ecs_cluster"
 	ECSCreatedAt           = "ecs_created_at"


### PR DESCRIPTION
- Recently we got into an issue where, hostname was different than
k8s host/node name. K8s node-name is configurable and that configured
node name will override the k8s host name.

- This PR will add one new metadata to hosts i.e
KUBERNETES_NODE_NAME which will tell the k8s node name and that can be
used to map the k8s node and actual hostname.

Signed-off-by: Akash Srivastava <akashsrivastava4927@gmail.com>